### PR TITLE
Various cleanup and compatibility fixes for python 3k.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 python:
-  - 2.5
   - 2.6
   - 2.7
+  - 3.3
 install:
-  - pip install -q -e . --use-mirrors
+  - pip install -q -e ".[test]" --use-mirrors
 script:
   - python setup.py test

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,0 @@
--r requirements.txt
-pytest==2.2.3
-Pygments==1.2
-Jinja2==2.3
-docutils>=0.10
-flexmock>=0.9.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-SQLAlchemy>=0.8.0
-phonenumbers>=5.4b1
-colour==0.0.2

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ SQLAlchemy-Utils
 
 Various utility functions and custom data types for SQLAlchemy.
 """
-
 from setuptools import setup, Command
 import subprocess
 
@@ -22,6 +21,7 @@ class PyTest(Command):
         errno = subprocess.call(['py.test'])
         raise SystemExit(errno)
 
+
 setup(
     name='SQLAlchemy-Utils',
     version='0.13.3',
@@ -37,11 +37,26 @@ setup(
     zip_safe=False,
     include_package_data=True,
     platforms='any',
-    install_requires=[
-        'SQLAlchemy>=0.8.0',
-        'phonenumbers>=5.4b1',
-        'colour==0.0.2'
+    dependency_links=[
+        # 5.6 supports python 3.x / pending release
+        'git+git://github.com/daviddrysdale/python-phonenumbers.git@python3'
+        '#egg=phonenumbers3k-5.6b1',
     ],
+    install_requires=[
+        'six',
+        'SQLAlchemy>=0.8.0',
+        'phonenumbers3k==5.6b1',
+        'colour>=0.0.3'
+    ],
+    extras_require={
+        'test': [
+            'pytest==2.2.3',
+            'Pygments>=1.2',
+            'Jinja2>=2.3',
+            'docutils>=0.10',
+            'flexmock>=0.9.7',
+        ]
+    },
     cmdclass={'test': PyTest},
     classifiers=[
         'Environment :: Web Environment',

--- a/sqlalchemy_utils/merge.py
+++ b/sqlalchemy_utils/merge.py
@@ -1,3 +1,4 @@
+import six
 import sqlalchemy as sa
 from sqlalchemy.engine import reflection
 from sqlalchemy.orm import object_session, mapperlib
@@ -51,7 +52,7 @@ class Merger(object):
 
     def raw_merge(self, session, table, old_values, new_values):
         conditions = []
-        for key, value in old_values.items():
+        for key, value in six.iteritems(old_values):
             conditions.append(getattr(table.c, key) == value)
         sql = (
             table

--- a/sqlalchemy_utils/operators.py
+++ b/sqlalchemy_utils/operators.py
@@ -1,3 +1,4 @@
+import six
 import sqlalchemy as sa
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -20,9 +20,7 @@ def count_sql_calls(conn, cursor, statement, parameters, context, executemany):
 
 class TestCase(object):
     def setup_method(self, method):
-        self.engine = create_engine(
-            'postgres://postgres@localhost/sqlalchemy_utils_test'
-        )
+        self.engine = create_engine('sqlite:///:memory:')
         self.connection = self.engine.connect()
         self.Base = declarative_base()
 

--- a/tests/test_scalar_list.py
+++ b/tests/test_scalar_list.py
@@ -1,3 +1,4 @@
+import six
 import sqlalchemy as sa
 from sqlalchemy_utils import ScalarListType
 from pytest import raises
@@ -33,7 +34,7 @@ class TestScalarUnicodeList(TestCase):
         class User(self.Base):
             __tablename__ = 'user'
             id = sa.Column(sa.Integer, primary_key=True)
-            some_list = sa.Column(ScalarListType(unicode))
+            some_list = sa.Column(ScalarListType(six.text_type))
 
             def __repr__(self):
                 return 'User(%r)' % self.id


### PR DESCRIPTION
- Switch to nose for the test runner.
  Personal preference really; it meshes nicely with unittest and
  comes built-in with a test runner for setuptools.
- All tests pass under both python 2.x and 3.x
- Remove requirements files and made use of extras_requires instead
- pip must install packages which leads to the test runner must
  be ran explicitly (`nosetests`). This is only until the two
  packages that have python3 support in an unreleased branch
  put out official releases.
