### PR TITLE
Add literal statement render utility.

### DIFF
--- a/sqlalchemy_utils/__init__.py
+++ b/sqlalchemy_utils/__init__.py
@@ -1,6 +1,7 @@
 from .exceptions import ImproperlyConfigured
 from .functions import (
-    sort_query, defer_except, escape_like, primary_keys, table_name
+    sort_query, defer_except, escape_like, primary_keys, table_name,
+    render_statement
 )
 from .listeners import coercion_listener
 from .merge import merge, Merger
@@ -40,6 +41,7 @@ __all__ = (
     merge,
     primary_keys,
     proxy_dict,
+    render_statement,
     table_name,
     ArrowType,
     ColorType,

--- a/tests/test_utility_functions.py
+++ b/tests/test_utility_functions.py
@@ -1,7 +1,10 @@
 import sqlalchemy as sa
 from sqlalchemy_utils import escape_like, defer_except
-from sqlalchemy_utils.functions import non_indexed_foreign_keys
 from tests import TestCase
+from sqlalchemy_utils.functions import (
+    non_indexed_foreign_keys,
+    render_statement
+)
 
 
 class TestEscapeLike(TestCase):
@@ -62,3 +65,19 @@ class TestFindNonIndexedForeignKeys(TestCase):
         ]
         assert 'category_id' in column_names
         assert 'author_id' not in column_names
+
+    def test_render_statement_query(self):
+        query = self.session.query(self.User).filter_by(id=3)
+        render = render_statement(query)
+
+        assert 'SELECT user.id, user.name' in render
+        assert 'FROM user' in render
+        assert 'WHERE user.id = 3' in render
+
+    def test_render_statement(self):
+        statement = self.User.__table__.select().where(self.User.id == 3)
+        render = render_statement(statement, bind=self.session.bind)
+
+        assert 'SELECT user.id, user.name' in render
+        assert 'FROM user' in render
+        assert 'WHERE user.id = 3' in render


### PR DESCRIPTION
Added a utility function I use for converting statements to literal SQL inside of alchemist.

``` python
>>> from sqlalchemy_utils import render_statement
>>> query = session.query(User).filter(User.id == 4)
>>> render_statement(query)
SELECT user.id, user.name
FROM user
WHERE user.id = 4
```
