### PR TITLE
Postgres Dialect for JSON

### DIFF
--- a/sqlalchemy_utils/types/json.py
+++ b/sqlalchemy_utils/types/json.py
@@ -58,7 +58,7 @@ class JSONType(sa.types.TypeDecorator):
             )
 
     def load_dialect_impl(self, dialect):
-        if dialect.name == 'postgresql':
+        if dialect.name in ['postgresql', 'postgres']:
             # Use the native JSON type.
             return dialect.type_descriptor(PostgresJSONType())
         else:


### PR DESCRIPTION
Using either postgres or postgresql in the connection string will work, hence the JSON support needs to recognise this.
