### PR TITLE
Make JSONType importable from root

### DIFF
--- a/sqlalchemy_utils/__init__.py
+++ b/sqlalchemy_utils/__init__.py
@@ -35,6 +35,7 @@ from .types import (
     instrumented_list,
     InstrumentedList,
     IPAddressType,
+    JSONType,
     LocaleType,
     Password,
     PasswordType,

--- a/sqlalchemy_utils/types/__init__.py
+++ b/sqlalchemy_utils/types/__init__.py
@@ -6,6 +6,7 @@ from .color import ColorType
 from .country import CountryType, Country
 from .email import EmailType
 from .ip_address import IPAddressType
+from .json import JSONType
 from .locale import LocaleType
 from .number_range import (
     NumberRangeRawType,
@@ -30,6 +31,7 @@ __all__ = (
     Country,
     EmailType,
     IPAddressType,
+    JSONType,
     LocaleType,
     NumberRangeRawType,
     NumberRangeType,


### PR DESCRIPTION
This makes it correct according to the documentation, which states it should be importable from root.

Couldn't we run doctests to catch issues like these?
