### PR TITLE
Fixed: Coercion to Arrow on bind param

### DIFF
--- a/sqlalchemy_utils/types/arrow.py
+++ b/sqlalchemy_utils/types/arrow.py
@@ -63,7 +63,7 @@ class ArrowType(types.TypeDecorator, ScalarCoercible):
 
     def process_bind_param(self, value, dialect):
         if value:
-            return value.datetime
+            return self._coerce(value).datetime
         return value
 
     def process_result_value(self, value, dialect):


### PR DESCRIPTION
This allows one to query via coerced values.

Example:

``` python
session.query(Post).filter(Post.created == "2014-02-07T16:30:40.254Z").all()
```
