### PR TITLE
UUIDType now detects postgresql dialect correctly

### DIFF
--- a/sqlalchemy_utils/types/uuid.py
+++ b/sqlalchemy_utils/types/uuid.py
@@ -59,7 +59,7 @@ class UUIDType(types.TypeDecorator, ScalarCoercible):
         if not isinstance(value, uuid.UUID):
             value = self._coerce(value)
 
-        if dialect == 'postgresql':
+        if dialect.name == 'postgresql':
             return str(value)
 
         return value.bytes if self.binary else value.hex
@@ -68,7 +68,7 @@ class UUIDType(types.TypeDecorator, ScalarCoercible):
         if value is None:
             return value
 
-        if dialect == 'postgresql':
+        if dialect.name == 'postgresql':
             return uuid.UUID(value)
 
         return uuid.UUID(bytes=value) if self.binary else uuid.UUID(value)


### PR DESCRIPTION
It was inconsistent.  When creating the field it used dialect.name, but in other places it just used dialect.
