### PR TITLE
Fixed ArrowType to store and retrieve time consistently.

### DIFF
--- a/sqlalchemy_utils/types/arrow.py
+++ b/sqlalchemy_utils/types/arrow.py
@@ -63,7 +63,7 @@ class ArrowType(types.TypeDecorator, ScalarCoercible):
 
     def process_bind_param(self, value, dialect):
         if value:
-            return self._coerce(value).datetime
+            return self._coerce(value).to('UTC').naive
         return value
 
     def process_result_value(self, value, dialect):


### PR DESCRIPTION
SQLAlchemy's handling of time is stupid.  If you hand it a datetime with an explicit time zone set, and attempt to put it in a "timestamp without time zone" field, it will convert it to your local time first.  This is probably not what you want!  Especially for ArrowType, because when you retrieve the value and pass it to arrow.get, arrow assumes the time is in UTC, when it's really in local time.  This leads to nonsense like this:

myrecord.time = time
db.session.commit()
myrecord.time != time # wtf!  It changed!

In this commit, I make the assumption that you always want to put UTC timestamps into your database, so I convert the incoming time to UTC and then discard the time zone so SQLAlchemy wont mess with it.

A future version of this type might allow you to specify what time zone you want to assume this database column actually represents, so you can convert to and from that time zone when saving and retrieving.
