### PR TITLE
Fix PasswordType

### DIFF
--- a/sqlalchemy_utils/types/password.py
+++ b/sqlalchemy_utils/types/password.py
@@ -143,7 +143,7 @@ class PasswordType(types.TypeDecorator, ScalarCoercible):
             scheme = getattr(__import__('passlib.hash').hash, name)
             length = 4 + len(scheme.name)
             length += len(str(getattr(scheme, 'max_rounds', '')))
-            length += scheme.max_salt_size or 0
+            length += getattr(scheme, 'max_salt_size', 0)
             length += getattr(
                 scheme,
                 'encoded_checksum_size',

--- a/tests/types/test_password.py
+++ b/tests/types/test_password.py
@@ -16,10 +16,11 @@ class TestPasswordType(TestCase):
                 schemes=[
                     'pbkdf2_sha512',
                     'pbkdf2_sha256',
-                    'md5_crypt'
+                    'md5_crypt',
+                    'hex_md5'
                 ],
 
-                deprecated=['md5_crypt']
+                deprecated=['md5_crypt', 'hex_md5']
             ))
 
             def __repr__(self):


### PR DESCRIPTION
This commit fixes an error when hex_md5 and other schemes that does not
have max_salt_size is used. This kind of schemes are needed to migrate from very
old and stupid databases.
