### PR TITLE
PasswordType: use RAW impl for Oracle instead of non-existent VARBINARY

### DIFF
--- a/sqlalchemy_utils/types/password.py
+++ b/sqlalchemy_utils/types/password.py
@@ -115,6 +115,7 @@ class PasswordType(types.TypeDecorator, ScalarCoercible):
 
     """
 
+    impl = types.VARBINARY(1024)
     python_type = Password
 
     def __init__(self, max_length=None, **kwargs):


### PR DESCRIPTION
If I'm not mistaken, the Oracle SQL DB (at least 11g R2) doesn't have a VARBINARY type.
This fix uses a RAW (binary) type instead for the Oracle dialect.
