### PR TITLE
Added python_type implementation to arrow, email, ipaddress, password, a...

### DIFF
--- a/sqlalchemy_utils/types/arrow.py
+++ b/sqlalchemy_utils/types/arrow.py
@@ -85,3 +85,7 @@ class ArrowType(types.TypeDecorator, ScalarCoercible):
         elif isinstance(value, datetime):
             value = arrow.get(value)
         return value
+
+    @property
+    def python_type(self):
+        return self.impl.type.python_type

--- a/sqlalchemy_utils/types/email.py
+++ b/sqlalchemy_utils/types/email.py
@@ -11,3 +11,7 @@ class EmailType(sa.types.TypeDecorator):
         if value is not None:
             return value.lower()
         return value
+
+    @property
+    def python_type(self):
+        return self.impl.type.python_type

--- a/sqlalchemy_utils/types/ip_address.py
+++ b/sqlalchemy_utils/types/ip_address.py
@@ -67,3 +67,7 @@ class IPAddressType(types.TypeDecorator, ScalarCoercible):
 
     def _coerce(self, value):
         return ip_address(value) if value else None
+
+    @property
+    def python_type(self):
+        return self.impl.type.python_type

--- a/sqlalchemy_utils/types/password.py
+++ b/sqlalchemy_utils/types/password.py
@@ -208,5 +208,9 @@ class PasswordType(types.TypeDecorator, ScalarCoercible):
 
         return value
 
+    @property
+    def python_type(self):
+        return self.impl.type.python_type
+
 
 Password.associate_with(PasswordType)

--- a/sqlalchemy_utils/types/url.py
+++ b/sqlalchemy_utils/types/url.py
@@ -61,3 +61,7 @@ class URLType(types.TypeDecorator, ScalarCoercible):
         if value is not None and not isinstance(value, furl):
             return furl(value)
         return value
+
+    @property
+    def python_type(self):
+        return self.impl.type.python_type


### PR DESCRIPTION
Implemented python_type on a few types. This makes it work with serialization libraries such as [marshmallow-sqlalchemy](http://marshmallow-sqlalchemy.readthedocs.org).

[python_type in SQLAlchemy docs](http://docs.sqlalchemy.org/en/latest/core/custom_types.html#sqlalchemy.types.TypeDecorator.python_type)