### PR TITLE
Fix asserts expecting failing update

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Changelog
 Here you can see the full list of changes between each SQLAlchemy-Utils release.
 
 
+0.30.2 (not yet released)
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Fixed ``assert_max_length``, ``assert_non_nullable``, ``assert_min_value`` and ``assert_max_value`` not properly raising an ``AssertionError`` when the assertion failed.
+
+
 0.30.1 (2015-05-06)
 ^^^^^^^^^^^^^^^^^^^
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,8 @@ extras_require = {
         'python-dateutil>=2.2',
         'pymysql',
         'flake8>=2.4.0',
-        'isort==3.9.6'
+        'isort==3.9.6',
+        'natsort==3.5.6',
     ],
     'anyjson': ['anyjson>=0.3.3'],
     'babel': ['Babel>=1.3'],

--- a/tests/test_asserts.py
+++ b/tests/test_asserts.py
@@ -9,20 +9,7 @@ from sqlalchemy_utils import (
     assert_non_nullable,
     assert_nullable
 )
-from sqlalchemy_utils.asserts import raises
 from tests import TestCase
-
-
-class TestRaises(object):
-    def test_matching_exception(self):
-        with raises(Exception):
-            raise Exception()
-        assert True
-
-    def test_non_matchin_exception(self):
-        with pytest.raises(Exception):
-            with raises(ValueError):
-                raise Exception()
 
 
 class AssertionTestCase(TestCase):
@@ -67,15 +54,15 @@ class TestAssertMaxLengthWithArray(AssertionTestCase):
         assert_max_length(self.user, 'fav_numbers', 8)
 
     def test_smaller_than_max_length(self):
-        with raises(AssertionError):
+        with pytest.raises(AssertionError):
             assert_max_length(self.user, 'fav_numbers', 7)
-        with raises(AssertionError):
+        with pytest.raises(AssertionError):
             assert_max_length(self.user, 'fav_numbers', 7)
 
     def test_bigger_than_max_length(self):
-        with raises(AssertionError):
+        with pytest.raises(AssertionError):
             assert_max_length(self.user, 'fav_numbers', 9)
-        with raises(AssertionError):
+        with pytest.raises(AssertionError):
             assert_max_length(self.user, 'fav_numbers', 9)
 
 
@@ -86,9 +73,9 @@ class TestAssertNonNullable(AssertionTestCase):
         assert_non_nullable(self.user, 'age')
 
     def test_nullable_column(self):
-        with raises(AssertionError):
+        with pytest.raises(AssertionError):
             assert_non_nullable(self.user, 'name')
-        with raises(AssertionError):
+        with pytest.raises(AssertionError):
             assert_non_nullable(self.user, 'name')
 
 
@@ -98,9 +85,9 @@ class TestAssertNullable(AssertionTestCase):
         assert_nullable(self.user, 'name')
 
     def test_non_nullable_column(self):
-        with raises(AssertionError):
+        with pytest.raises(AssertionError):
             assert_nullable(self.user, 'age')
-        with raises(AssertionError):
+        with pytest.raises(AssertionError):
             assert_nullable(self.user, 'age')
 
 
@@ -114,15 +101,15 @@ class TestAssertMaxLength(AssertionTestCase):
         assert_max_length(self.user, 'email', 200)
 
     def test_smaller_than_max_length(self):
-        with raises(AssertionError):
+        with pytest.raises(AssertionError):
             assert_max_length(self.user, 'name', 19)
-        with raises(AssertionError):
+        with pytest.raises(AssertionError):
             assert_max_length(self.user, 'name', 19)
 
     def test_bigger_than_max_length(self):
-        with raises(AssertionError):
+        with pytest.raises(AssertionError):
             assert_max_length(self.user, 'name', 21)
-        with raises(AssertionError):
+        with pytest.raises(AssertionError):
             assert_max_length(self.user, 'name', 21)
 
 
@@ -132,15 +119,15 @@ class TestAssertMinValue(AssertionTestCase):
         assert_min_value(self.user, 'age', 0)
 
     def test_smaller_than_min_value(self):
-        with raises(AssertionError):
+        with pytest.raises(AssertionError):
             assert_min_value(self.user, 'age', -1)
-        with raises(AssertionError):
+        with pytest.raises(AssertionError):
             assert_min_value(self.user, 'age', -1)
 
     def test_bigger_than_min_value(self):
-        with raises(AssertionError):
+        with pytest.raises(AssertionError):
             assert_min_value(self.user, 'age', 1)
-        with raises(AssertionError):
+        with pytest.raises(AssertionError):
             assert_min_value(self.user, 'age', 1)
 
 
@@ -150,13 +137,13 @@ class TestAssertMaxValue(AssertionTestCase):
         assert_max_value(self.user, 'age', 150)
 
     def test_smaller_than_max_value(self):
-        with raises(AssertionError):
+        with pytest.raises(AssertionError):
             assert_max_value(self.user, 'age', 149)
-        with raises(AssertionError):
+        with pytest.raises(AssertionError):
             assert_max_value(self.user, 'age', 149)
 
     def test_bigger_than_max_value(self):
-        with raises(AssertionError):
+        with pytest.raises(AssertionError):
             assert_max_value(self.user, 'age', 151)
-        with raises(AssertionError):
+        with pytest.raises(AssertionError):
             assert_max_value(self.user, 'age', 151)


### PR DESCRIPTION
`sqlalchemy_utils.asserts.raises` was broken. I removed it and replaced
it's usage with traditional `try..except` and with `pytest.raises` in tests.