### PR TITLE
Allowing String based Columns for `ChoiceType` if python's `Enum` class is used

### DIFF
--- a/sqlalchemy_utils/types/choice.py
+++ b/sqlalchemy_utils/types/choice.py
@@ -199,7 +199,7 @@ class ChoiceTypeImpl(object):
 
 
 class EnumTypeIntImpl(object):
-    """The implementation for the ``Enum`` usage."""
+    """The implementation for the ``Enum`` usage with Integer based DB type."""
 
     def __init__(self, enum_class):
         if Enum is None:

--- a/sqlalchemy_utils/types/choice.py
+++ b/sqlalchemy_utils/types/choice.py
@@ -205,7 +205,7 @@ class ChoiceTypeImpl(object):
 
 
 class EnumTypeIntImpl(object):
-    """The implementation for the ``Enum`` usage with Integer based DB type."""
+    """The implementation for the ``Enum`` usage with Integer based Columns."""
 
     def __init__(self, enum_class):
         if Enum is None:
@@ -231,7 +231,7 @@ class EnumTypeIntImpl(object):
 
 class EnumTypeStringImpl(object):
 
-    """The implementation for the ``Enum`` usage with String based DB type."""
+    """The implementation for the ``Enum`` usage with String based Columns."""
 
     def __init__(self, enum_class):
         if Enum is None:

--- a/sqlalchemy_utils/types/choice.py
+++ b/sqlalchemy_utils/types/choice.py
@@ -229,8 +229,8 @@ class EnumTypeIntImpl(object):
     def process_result_value(self, value, dialect):
         return self.enum_class(value) if value else None
 
-class EnumTypeStringImpl(object):
 
+class EnumTypeStringImpl(object):
     """The implementation for the ``Enum`` usage with String based Columns."""
 
     def __init__(self, enum_class):
@@ -251,8 +251,8 @@ class EnumTypeStringImpl(object):
             return None
 
         for member in self.enum_class:
-             dbvalue = getattr(member, 'dbvalue', None)
-             if dbvalue == value:
+            dbvalue = getattr(member, 'dbvalue', None)
+            if dbvalue == value:
                 return member
 
         return self.enum_class[value]
@@ -266,8 +266,8 @@ class EnumTypeStringImpl(object):
             return None
 
         for member in self.enum_class:
-             dbvalue = getattr(member, 'dbvalue', None)
-             if dbvalue == value:
+            dbvalue = getattr(member, 'dbvalue', None)
+            if dbvalue == value:
                 return member
 
         return self.enum_class[value]

--- a/sqlalchemy_utils/types/choice.py
+++ b/sqlalchemy_utils/types/choice.py
@@ -146,7 +146,8 @@ class ChoiceType(types.TypeDecorator, ScalarCoercible):
         if (
             Enum is not None and
             isinstance(choices, type) and
-            issubclass(choices, Enum)
+            issubclass(choices, Enum) and
+            isinstance(impl, types.Integer)
         ):
             self.type_impl = EnumTypeIntImpl(enum_class=choices)
         else:

--- a/sqlalchemy_utils/types/choice.py
+++ b/sqlalchemy_utils/types/choice.py
@@ -129,7 +129,7 @@ class ChoiceType(types.TypeDecorator, ScalarCoercible):
             __tablename__ = 'user'
             id = sa.Column(sa.Integer, primary_key=True)
             name = sa.Column(sa.Unicode(255))
-            type = sa.Column(ChoiceType(TYPES))
+            type = sa.Column(ChoiceType(UserType, impl=sa.Integer()))
 
 
         user = User(type=UserType.admin)

--- a/sqlalchemy_utils/types/choice.py
+++ b/sqlalchemy_utils/types/choice.py
@@ -150,6 +150,12 @@ class ChoiceType(types.TypeDecorator, ScalarCoercible):
             isinstance(impl, types.Integer)
         ):
             self.type_impl = EnumTypeIntImpl(enum_class=choices)
+        elif (
+            Enum is not None and
+            isinstance(choices, type) and
+            issubclass(choices, Enum)
+        ):
+            self.type_impl = EnumTypeStringImpl(enum_class=choices)
         else:
             self.type_impl = ChoiceTypeImpl(choices=choices)
 

--- a/sqlalchemy_utils/types/choice.py
+++ b/sqlalchemy_utils/types/choice.py
@@ -148,7 +148,7 @@ class ChoiceType(types.TypeDecorator, ScalarCoercible):
             isinstance(choices, type) and
             issubclass(choices, Enum)
         ):
-            self.type_impl = EnumTypeImpl(enum_class=choices)
+            self.type_impl = EnumTypeIntImpl(enum_class=choices)
         else:
             self.type_impl = ChoiceTypeImpl(choices=choices)
 
@@ -197,7 +197,7 @@ class ChoiceTypeImpl(object):
         return value
 
 
-class EnumTypeImpl(object):
+class EnumTypeIntImpl(object):
     """The implementation for the ``Enum`` usage."""
 
     def __init__(self, enum_class):

--- a/tests/types/test_choice.py
+++ b/tests/types/test_choice.py
@@ -80,30 +80,7 @@ class TestChoiceTypeWithCustomUnderlyingType(TestCase):
         assert type_.impl == sa.Integer
 
 
-@mark.skipif('Enum is None')
-class TestEnumType(TestCase):
-    def create_models(self):
-        class OrderStatus(Enum):
-            unpaid = 1
-            paid = 2
-
-        class Order(self.Base):
-            __tablename__ = 'order'
-            id_ = sa.Column(sa.Integer, primary_key=True)
-            status = sa.Column(
-                ChoiceType(OrderStatus, impl=sa.Integer()),
-                default=OrderStatus.unpaid
-            )
-
-            def __repr__(self):
-                return 'Order(%r, %r)' % (self.id_, self.status)
-
-            def pay(self):
-                self.status = OrderStatus.paid
-
-        self.OrderStatus = OrderStatus
-        self.Order = Order
-
+class TestEnumType(object):
     def test_parameter_processing(self):
         order = self.Order()
 
@@ -129,3 +106,53 @@ class TestEnumType(TestCase):
         self.session.commit()
 
         assert order.status is self.OrderStatus.paid
+
+@mark.skipif('Enum is None')
+class TestEnumIntType(TestCase, TestEnumType):
+    def create_models(self):
+        class OrderStatus(Enum):
+            unpaid = 1
+            paid = 2
+
+        class Order(self.Base):
+            __tablename__ = 'order'
+            id_ = sa.Column(sa.Integer, primary_key=True)
+            status = sa.Column(
+                ChoiceType(OrderStatus, impl=sa.Integer()),
+                default=OrderStatus.unpaid
+            )
+
+            def __repr__(self):
+                return 'Order(%r, %r)' % (self.id_, self.status)
+
+            def pay(self):
+                self.status = OrderStatus.paid
+
+        self.OrderStatus = OrderStatus
+        self.Order = Order
+
+@mark.skipif('Enum is None')
+class TestEnumStringType(TestCase, TestEnumType):
+    def create_models(self):
+        class OrderStatus(Enum):
+            unpaid = 1
+            paid = 2
+
+        OrderStatus.unpaid.dbvalue = 'unpaid'
+
+        class Order(self.Base):
+            __tablename__ = 'order'
+            id_ = sa.Column(sa.Integer, primary_key=True)
+            status = sa.Column(
+                ChoiceType(OrderStatus, impl=sa.Enum('unpaid', 'paid')),
+                default=OrderStatus.unpaid
+            )
+
+            def __repr__(self):
+                return 'Order(%r, %r)' % (self.id_, self.status)
+
+            def pay(self):
+                self.status = OrderStatus.paid
+
+        self.OrderStatus = OrderStatus
+        self.Order = Order


### PR DESCRIPTION
Actually you can only use python's native `Enum` class with an Integer Column.
This MR allows also using other Column Types like `ENUM`, `TEXT`, `CHAR` (string based).
Especially the `ENUM` type is quite intuitive for mapping to the `Enum` class.

By default it uses the `name` of the `Enum` inherited class variable as mapping to the column.
But you can define the value for the column also by the `dbvalue` attribute, which you can set on the `Enum` inherited class variables.

Edit: I check for `isinstance(impl, types.Integer)`. Well `types.Integer` is a base class for all Integer types, so it should works well.

Something like the following should work:

``` python
        import enum

        class UserType(enum.Enum):
            admin = 1
            regular = 2

        UserType.admin.dbvalue = 'administrator'

        class User(Base):
            __tablename__ = 'user'
            id = sa.Column(sa.Integer, primary_key=True)
            name = sa.Column(sa.Unicode(255))
            type = sa.Column(ChoiceType(UserType, impl=sa.Enum('administrator', 'regular')))


        user = User(type=1)
        user.type  # <UserType.admin: 1>

```

Additionally it corrects an small copy and paste error in the already existing doc of the module fb57bb9402e9004396a03a64c0a6c80e975898cf

**TODO** (Edit)
- [ ] Docs for the new features (lets first see if the MR is accepted)
- [ ] Testing? It works for me with an `ENUM` and a varchar column
- [ ] Code review
- [ ] Add Test for Travis CI (need a string column in the test DB for that)
