### PR TITLE
Some drivers convert uuid values to uuid.UUID by themselves

### DIFF
--- a/sqlalchemy_utils/types/uuid.py
+++ b/sqlalchemy_utils/types/uuid.py
@@ -73,6 +73,10 @@ class UUIDType(types.TypeDecorator, ScalarCoercible):
             return value
 
         if self.native and dialect.name == 'postgresql':
+            if isinstance(value, uuid.UUID):
+                # Some drivers convert PostgreSQL's uuid values to
+                # Python's uuid.UUID objects by themselves
+                return value
             return uuid.UUID(value)
 
         return uuid.UUID(bytes=value) if self.binary else uuid.UUID(value)


### PR DESCRIPTION
Some drivers (e.g. [py-postgresql][1]) convert PostgreSQL `uuid` values to Python `uuid.UUID` objects by themselves.

[1]: http://python.projects.pgfoundry.org/