### PR TITLE
Fix locale territory parsing

### DIFF
--- a/sqlalchemy_utils/types/locale.py
+++ b/sqlalchemy_utils/types/locale.py
@@ -67,7 +67,7 @@ class LocaleType(types.TypeDecorator, ScalarCoercible):
 
     def process_result_value(self, value, dialect):
         if value is not None:
-            return babel.Locale(value)
+            return babel.Locale.parse(value)
 
     def _coerce(self, value):
         if value is not None and not isinstance(value, babel.Locale):

--- a/tests/types/test_locale.py
+++ b/tests/types/test_locale.py
@@ -28,6 +28,14 @@ class TestLocaleType(TestCase):
 
         user = self.session.query(self.User).first()
 
+    def test_territory_parsing(self):
+        ko_kr = locale.babel.Locale(u'ko', territory=u'KR')
+        user = self.User(locale=ko_kr)
+        self.session.add(user)
+        self.session.commit()
+
+        assert self.session.query(self.User.locale).first()[0] == ko_kr
+
     def test_scalar_attributes_get_coerced_to_objects(self):
         user = self.User(locale='en_US')
 


### PR DESCRIPTION
`LocaleType` had lost locale’s territory, for example, `Locale('ja', territory='JP')` becomes `Locale('ja_JP')`.  This patch fixes the bug.  (See also the added test.)