### PR TITLE
JSONType: Allow specifying `encode_cls` and `decode_cls`

### DIFF
--- a/sqlalchemy_utils/types/json.py
+++ b/sqlalchemy_utils/types/json.py
@@ -28,13 +28,12 @@ except ImportError:
 
 
 class JSONType(sa.types.TypeDecorator):
-    """
+    '''
     JSONType offers way of saving JSON data structures to database. On
     PostgreSQL the underlying implementation of this data type is 'json' while
     on other databases its simply 'text'.
 
     ::
-
 
         from sqlalchemy_utils import JSONType
 
@@ -53,14 +52,78 @@ class JSONType(sa.types.TypeDecorator):
             'max-speed': '400 mph'
         }
         session.commit()
-    """
+
+    Python's JSON module doesn't have native support for encoding and decoding
+    all data types -- most notably, it chokes on datetime objects. By passing
+    custom subclasses of :class:`~json.JSONEncoder` and
+    :class:`~json.JSONDecoder` to JSONType, you can teach it how to encode
+    and decode any data type you wish. For example, to handle datetime objects,
+    you can do the following::
+
+        import json
+        import datetime
+        import re
+        from sqlalchemy_utils import JSONType
+
+
+        DATETIME_ISO_RE = re.compile(r"""
+            (?P<year>\d{4})-
+            (?P<month>\d{2})-
+            (?P<day>\d{2})T
+            (?P<hour>\d{2}):
+            (?P<minute>\d{2}):
+            (?P<second>\d{2})
+        """, re.VERBOSE)
+
+        class CustomJSONEncoder(json.JSONEncoder):
+            def default(self, obj):
+                if isinstance(obj, datetime.datetime):
+                    return obj.replace(microsecond=0).isoformat()
+                return super(CustomJSONEncoder, self).default(obj)
+
+        class CustomJSONDecoder(json.JSONDecoder):
+            def decode(self, obj):
+                match = DATETIME_ISO_RE.match(obj)
+                if match:
+                    return datetime.datetime(
+                        year=int(match.group('year')),
+                        month=int(match.group('month')),
+                        day=int(match.group('day')),
+                        hour=int(match.group('hour')),
+                        minute=int(match.group('minute')),
+                        second=int(match.group('second')),
+                    )
+                return super(CustonJSONDecoder, self).decode(obj)
+
+        class Product(Base):
+            __tablename__ = 'person'
+            id = sa.Column(sa.Integer, autoincrement=True)
+            name = sa.Column(sa.Unicode(50))
+            details = sa.Column(JSONType,
+                encode_cls=CustomJSONEncoder,
+                decode_cls=CustomJSONDecoder,
+            )
+
+
+        product = Product()
+        product.details = {
+            'constructed': datetime(2016, 2, 15, 14, 15, 0)
+        }
+        session.commit()
+
+    For more information, read the documentation for :class:`json.JSONEncoder`
+    and :class:`json.JSONDecoder`.
+
+    '''
     impl = sa.UnicodeText
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, encode_cls=None, decode_cls=None, *args, **kwargs):
         if json is None:
             raise ImproperlyConfigured(
                 'JSONType needs anyjson package installed.'
             )
+        self.encode_cls = encode_cls
+        self.decode_cls = decode_cls
         super(JSONType, self).__init__(*args, **kwargs)
 
     def load_dialect_impl(self, dialect):
@@ -77,12 +140,12 @@ class JSONType(sa.types.TypeDecorator):
         if dialect.name == 'postgresql' and has_postgres_json:
             return value
         if value is not None:
-            value = six.text_type(json.dumps(value))
+            value = six.text_type(json.dumps(value, cls=self.encode_cls))
         return value
 
     def process_result_value(self, value, dialect):
         if dialect.name == 'postgresql':
             return value
         if value is not None:
-            value = json.loads(value)
+            value = json.loads(value, cls=self.decode_cls)
         return value

--- a/tests/types/test_json.py
+++ b/tests/types/test_json.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 import pytest
 import sqlalchemy as sa
+import datetime
+import re
+from json import JSONEncoder, JSONDecoder
 
 from sqlalchemy_utils.types import json
 
@@ -12,6 +15,52 @@ def Document(Base):
         id = sa.Column(sa.Integer, primary_key=True)
         json = sa.Column(json.JSONType)
     return Document
+
+@pytest.fixture
+def CustomJSONEncoder():
+    class CustomJSONEncoder(JSONEncoder):
+        def default(self, obj):
+            if isinstance(obj, datetime.datetime):
+                return obj.replace(microsecond=0).isoformat()
+            return super(CustomJSONEncoder, self).default(obj)
+    return CustomJSONEncoder
+
+@pytest.fixture
+def CustomJSONDecoder():
+    DATETIME_ISO_RE = re.compile(r"""
+        (?P<year>\d{4})-
+        (?P<month>\d{2})-
+        (?P<day>\d{2})T
+        (?P<hour>\d{2}):
+        (?P<minute>\d{2}):
+        (?P<second>\d{2})
+    """, re.VERBOSE)
+
+    class CustomJSONDecoder(JSONDecoder):
+        def decode(self, obj):
+            match = DATETIME_ISO_RE.match(obj)
+            if match:
+                return datetime.datetime(
+                    year=int(match.group('year')),
+                    month=int(match.group('month')),
+                    day=int(match.group('day')),
+                    hour=int(match.group('hour')),
+                    minute=int(match.group('minute')),
+                    second=int(match.group('second')),
+                )
+            return super(CustomJSONDecoder, self).decode(obj)
+    return CustomJSONDecoder
+
+
+@pytest.fixture
+def DateTimeEnabledDocument(Base, CustomJSONEncoder, CustomJSONDecoder):
+    class DateTimeEnabledDocument(Base):
+        __tablename__ = 'dt_document'
+        id = sa.Column(sa.Integer, primary_key=True)
+        json = sa.Column(json.JSONType(
+            encode_cls=CustomJSONEncoder, decode_cls=CustomJSONDecoder
+        ))
+    return DateTimeEnabledDocument
 
 
 @pytest.fixture
@@ -53,6 +102,19 @@ class JSONTestCase(object):
 
         document = session.query(Document).first()
         assert document.json == {'something': u'äääööö'}
+
+    def test_custom_encode_decode_classes(self, session, DateTimeEnabledDocument):
+        document = DateTimeEnabledDocument(
+            json={'created': datetime.datetime(2016, 1, 19, 9, 15, 18)}
+        )
+
+        session.add(document)
+        session.commit()
+
+        document = session.query(DateTimeEnabledDocument).first()
+        assert document.json == {
+            'created': datetime.datetime(2016, 1, 19, 9, 15, 18)
+        }
 
 
 @pytest.mark.skipif('json.json is None')


### PR DESCRIPTION
This commit allows a developer using `JSONType` to specify a JSONEncoder and JSONDecoder subclass, to allow encoding and decoding arbitrary values with JSON. The canonical example is datetime objects, but any object can be encoded and decoded in this way.