### PR TITLE
whitespace causes setup.py parsing failure on Ubuntu 14.04

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,12 +41,12 @@ extras_require = {
     'arrow': ['arrow>=0.3.4'],
     'intervals': ['intervals>=0.2.4'],
     'phone': ['phonenumbers>=5.9.2'],
-    'password': ['passlib >= 1.6, < 2.0'],
+    'password': ['passlib>=1.6,<2.0'],
     'color': ['colour>=0.0.4'],
     'ipaddress': ['ipaddr'] if not PY3 else [],
     'enum': ['enum34'] if sys.version_info < (3, 4) else [],
     'timezone': ['python-dateutil'],
-    'url': ['furl >= 0.4.1'],
+    'url': ['furl>=0.4.1'],
     'encrypted': ['cryptography>=0.6']
 }
 


### PR DESCRIPTION
When trying to install OpenStack via devstack I noticed a failure in the pip install of SQLAlchemy-Utils.  I traced it back to the setup.py containing whitespace in some of the fields of extras_require which seemed to throw the parsing on the default python install of Ubuntu 14.04, or at least the python on a system half through installing devstack from a default Ubuntu 14.04.

Error when running "python setup.py":

error in SQLAlchemy-Utils setup command: 'extras_require' must be a dictionary whose values are strings or lists of strings containing valid project/version requirement specifiers.
