### PR TITLE
Ensure that queried entities are taken from the alias

### DIFF
--- a/sqlalchemy_utils/i18n.py
+++ b/sqlalchemy_utils/i18n.py
@@ -97,9 +97,13 @@ class TranslationHybrid(object):
 
     def expr_factory(self, attr):
         def expr(cls):
+            cls_attr = getattr(cls, attr.key)
             current_locale = cast_locale_expr(cls, self.current_locale)
             default_locale = cast_locale_expr(cls, self.default_locale)
-            return sa.func.coalesce(attr[current_locale], attr[default_locale])
+            return sa.func.coalesce(
+                cls_attr[current_locale],
+                cls_attr[default_locale]
+            )
         return expr
 
     def __call__(self, attr):

--- a/tests/test_translation_hybrid.py
+++ b/tests/test_translation_hybrid.py
@@ -2,6 +2,7 @@ import pytest
 import sqlalchemy as sa
 from flexmock import flexmock
 from sqlalchemy.dialects.postgresql import HSTORE
+from sqlalchemy.orm import aliased
 
 from sqlalchemy_utils import i18n, TranslationHybrid  # noqa
 
@@ -117,3 +118,10 @@ class TestTranslationHybrid(object):
             locale = sa.Column(sa.String)
 
         Article.name
+
+    def test_no_implicit_join_when_using_aliased_entities(self, session, City):
+        # Ensure that queried entities are taken from the alias so that
+        # there isn't an extra join to the original entity.
+        CityAlias = aliased(City)
+        query_str = str(session.query(CityAlias.name))
+        assert query_str.endswith('FROM city AS city_1')


### PR DESCRIPTION
Previous behavior was to implicitly join in the parent of the alias to the query, causing two joins when there should only be one.