### PR TITLE
Remove unnecessary argument

### DIFF
--- a/sqlalchemy_utils/aggregates.py
+++ b/sqlalchemy_utils/aggregates.py
@@ -376,7 +376,7 @@ from .relationships import (
     select_correlated_expression
 )
 
-aggregated_attrs = WeakKeyDictionary(defaultdict(list))
+aggregated_attrs = WeakKeyDictionary()
 
 
 class AggregatedAttribute(declared_attr):


### PR DESCRIPTION
Providing empty dictionary is same as providing nothing.