### PR TITLE
Try using LazyCryptContext if it is possible

### DIFF
--- a/sqlalchemy_utils/types/password.py
+++ b/sqlalchemy_utils/types/password.py
@@ -11,9 +11,13 @@ from .scalar_coercible import ScalarCoercible
 passlib = None
 try:
     import passlib
-    from passlib.context import CryptContext
 except ImportError:
     pass
+else:
+    try:
+        from passlib.context import LazyCryptContext as CryptContext
+    except ImportError:
+        from passlib.context import CryptContext
 
 
 class Password(Mutable, object):


### PR DESCRIPTION
Since passlib version 1.6 the LazyCryptContext was introduced.
If you are using Flask and rely on its config, for example anyway your models are hooked to the connection string with init_app of the extension so it makes sense to use Flask config.
There should be a way to configure passlib parameters like password schemes and change them without re-deploying your code but modifying .ini file and reload workers.

The way LazyCryptContext works - it allows you to pass a callable to alter the CryptContext arguments.
For example
.. code:: python

    class User(db.Model):
        __tablename__ = 'user'

        password = db.Column(
            PasswordType(
                onload=lambda **kwargs: dict(
                    schemes=flask.current_app.config['PASSWORD_SCHEMES'],
                    **kwargs
                ),
            ),
            unique=False,
            nullable=False,
        )

So that onload would go to LazyCryptContext and later on to the CryptContext.
The solution uses import fallback to CryptContext to be compatible with the older versions.