### PR TITLE
Use LazyCryptContext to be able to read passlib attrs from the Flask config

### DIFF
--- a/sqlalchemy_utils/types/password.py
+++ b/sqlalchemy_utils/types/password.py
@@ -11,7 +11,7 @@ from .scalar_coercible import ScalarCoercible
 passlib = None
 try:
     import passlib
-    from passlib.context import CryptContext
+    from passlib.context import LazyCryptContext
 except ImportError:
     pass
 
@@ -82,7 +82,7 @@ class PasswordType(types.TypeDecorator, ScalarCoercible):
     verifying them using a pythonic interface.
 
     All keyword arguments (aside from max_length) are forwarded to the
-    construction of a `passlib.context.CryptContext` object.
+    construction of a `passlib.context.LazyCryptContext` object.
 
     The following usage will create a password column that will
     automatically hash new passwords as `pbkdf2_sha512` but still compare
@@ -128,7 +128,7 @@ class PasswordType(types.TypeDecorator, ScalarCoercible):
             )
 
         # Construct the passlib crypt context.
-        self.context = CryptContext(**kwargs)
+        self.context = LazyCryptContext(**kwargs)
 
         if max_length is None:
             max_length = self.calculate_max_length()


### PR DESCRIPTION
Since passlib version 1.6 the LazyCryptContext was introduced.
If you are using Flask and rely on its config, for example anyway your models are hooked to the connection string with init_app of the extension so it makes sense to use Flask config.
There should be a way to configure passlib parameters like password schemes and change them without re-deploying your code but modifying .ini file and reload workers.

The way LazyCryptContext works - it allows you to pass a callable to alter the CryptContext arguments.
For example
.. code:: python

    class User(db.Model):
        __tablename__ = 'user'

        password = db.Column(
            PasswordType(
                onload=lambda **kwargs: dict(
                    schemes=flask.current_app.config['PASSWORD_SCHEMES'],
                    **kwargs
                ),
            ),
            unique=False,
            nullable=False,
        )

So that onload would go to LazyCryptContext and later on to the CryptContext.
Since 1.6 is a minimum requirement we can simply change it to use LazyCryptContext