### PR TITLE
Handle default sqlite database

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -68,6 +68,11 @@ def sqlite_memory_dsn():
 
 
 @pytest.fixture
+def sqlite_none_database_dsn():
+    return 'sqlite://'
+
+
+@pytest.fixture
 def sqlite_file_dsn():
     return 'sqlite:///{0}.db'.format(db_name)
 

--- a/sqlalchemy_utils/functions/database.py
+++ b/sqlalchemy_utils/functions/database.py
@@ -575,8 +575,9 @@ def drop_database(url):
 
     engine = sa.create_engine(url)
 
-    if engine.dialect.name == 'sqlite' and url.database != ':memory:':
-        os.remove(url.database)
+    if engine.dialect.name == 'sqlite' and database != ':memory:':
+        if database:
+            os.remove(database)
 
     elif engine.dialect.name == 'postgresql' and engine.driver == 'psycopg2':
         from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT

--- a/sqlalchemy_utils/functions/database.py
+++ b/sqlalchemy_utils/functions/database.py
@@ -466,7 +466,12 @@ def database_exists(url):
         return bool(engine.execute(text).scalar())
 
     elif engine.dialect.name == 'sqlite':
-        return database == ':memory:' or os.path.exists(database)
+        if database:
+            return database == ':memory:' or os.path.exists(database)
+        else:
+            # The default SQLAlchemy database is in memory,
+            # and :memory is not required, thus we should support that use-case
+            return True
 
     else:
         text = 'SELECT 1'
@@ -538,7 +543,8 @@ def create_database(url, encoding='utf8', template=None):
         engine.execute(text)
 
     elif engine.dialect.name == 'sqlite' and database != ':memory:':
-        open(database, 'w').close()
+        if database:
+            open(database, 'w').close()
 
     else:
         text = 'CREATE DATABASE {0}'.format(quote(engine, database))

--- a/tests/functions/test_database.py
+++ b/tests/functions/test_database.py
@@ -27,6 +27,12 @@ class TestDatabaseSQLiteMemory(object):
         assert database_exists(dsn)
 
 
+@pytest.mark.usefixture('sqlite_none_database_dsn')
+class TestDatabaseSQLiteMemoryNoDatabaseString(object):
+    def test_exists_memory_none_database(self, sqlite_none_database_dsn):
+        assert database_exists(sqlite_none_database_dsn)
+
+
 @pytest.mark.usefixtures('sqlite_file_dsn')
 class TestDatabaseSQLiteFile(DatabaseTest):
     pass


### PR DESCRIPTION
SQLAlchemy's documentation states a SQLite database with a default to an in-memory database. The docs say you only need to provide a URL of "sqlite://" to get this functionality.

`create_database`, `database_exists`, and `drop_database` all did not handle this, in addition `drop_database` improperly reference the `url.database` after if is set to `None`. This was changed to use the `database` reference like the rest of the database types.

