### PR TITLE
Wrap PhoneNumber parse exception so SQLAlchemy won't wrap/swallow it

### DIFF
--- a/sqlalchemy_utils/__init__.py
+++ b/sqlalchemy_utils/__init__.py
@@ -82,6 +82,7 @@ from .types import (  # noqa
     Password,
     PasswordType,
     PhoneNumber,
+    PhoneNumberParseException,
     PhoneNumberType,
     register_composites,
     remove_composite_listeners,

--- a/sqlalchemy_utils/types/__init__.py
+++ b/sqlalchemy_utils/types/__init__.py
@@ -20,7 +20,11 @@ from .pg_composite import (  # noqa
     register_composites,
     remove_composite_listeners
 )
-from .phone_number import PhoneNumber, PhoneNumberType  # noqa
+from .phone_number import (  # noqa
+    PhoneNumber,
+    PhoneNumberParseException,
+    PhoneNumberType
+)
 from .range import (  # noqa
     DateRangeType,
     DateTimeRangeType,

--- a/tests/functions/test_make_order_by_deterministic.py
+++ b/tests/functions/test_make_order_by_deterministic.py
@@ -46,7 +46,8 @@ class TestMakeOrderByDeterministic(object):
     def test_column_property(self, session, User):
         query = session.query(User).order_by(User.email_lower)
         query = make_order_by_deterministic(query)
-        assert_contains('lower("user".name), "user".id ASC', query)
+        assert_contains('lower("user".name) AS lower_1', query)
+        assert_contains('lower_1, "user".id ASC', query)
 
     def test_unique_column(self, session, User):
         query = session.query(User).order_by(User.email)


### PR DESCRIPTION
Currently, if any type throws an exception that doesn't inherit from SQLAlchemy's [`DontWrapMixin`](http://docs.sqlalchemy.org/en/latest/core/exceptions.html#sqlalchemy.exc.DontWrapMixin) then SQLAlchemy wraps the error as a `StatementError`.

This PR wraps the `NumberParseException` from `python-phonenumbers` in a custom exception using the `DontWrapMixin` so we retain the original error message as well as a unique type for this exception. If this approach seems acceptable, I can work on wrapping the other types as well.