### PR TITLE
Fix for phonenumber test failing (unicode issue)

### DIFF
--- a/tests/types/test_phonenumber.py
+++ b/tests/types/test_phonenumber.py
@@ -90,8 +90,8 @@ class TestPhoneNumber(object):
         try:
             session.execute(
                 User.__table__.insert().values(
-                    name='Someone',
-                    phone_number='abc'
+                    name=u'Someone',
+                    phone_number=u'abc'
                 )
             )
         except PhoneNumberParseException:


### PR DESCRIPTION
A different exception was being thrown in py27 since we passed in
non-unicode characters for the name field.