### PR TITLE
Fix issue with PasswordType & Flask-Migrate

### DIFF
--- a/sqlalchemy_utils/types/password.py
+++ b/sqlalchemy_utils/types/password.py
@@ -157,6 +157,9 @@ class PasswordType(types.TypeDecorator, ScalarCoercible):
 
         self._max_length = max_length
 
+    def __repr__(self):
+        return 'PasswordType(max_length={length})'.format(length=self.length)
+
     @property
     def length(self):
         """Get column length."""


### PR DESCRIPTION
When executing command `python manage.py in model contains PasswordType field the following error appeares: "raise KeyError("unknown CryptContext keyword: %r" % (key,))
KeyError: "unknown CryptContext keyword: 'length'""