### PR TITLE
Add __repr__ for PasswordType and TimezoneType for integration with Flask-Migrate

### DIFF
--- a/sqlalchemy_utils/types/password.py
+++ b/sqlalchemy_utils/types/password.py
@@ -157,6 +157,9 @@ class PasswordType(types.TypeDecorator, ScalarCoercible):
 
         self._max_length = max_length
 
+    def __repr__(self):
+        return 'PasswordType(max_length={length})'.format(length=self.length)
+
     @property
     def length(self):
         """Get column length."""

--- a/sqlalchemy_utils/types/timezone.py
+++ b/sqlalchemy_utils/types/timezone.py
@@ -70,6 +70,9 @@ class TimezoneType(types.TypeDecorator, ScalarCoercible):
                 "'TimezoneType'"
             )
 
+    def __repr__(self):
+        return 'TimezoneType(backend=\'{backend}\')'.format(backend=self.backend)
+
     def _coerce(self, value):
         if value and not isinstance(value, self.python_type):
             obj = self._to(value)


### PR DESCRIPTION
During executing `python manage.py db migrate` from Flask-Migrate the issue with `length` property appears. To fix this isssue I added **repr** methods for PasswordType and TimezoneType. Also in Flask-Migrate I changed Mako-template (https://github.com/miguelgrinberg/Flask-Migrate/pull/112). Just without any tests. Tests will write later
