### PR TITLE
Allow setting custom length to EmailType, refs #229

### DIFF
--- a/sqlalchemy_utils/types/email.py
+++ b/sqlalchemy_utils/types/email.py
@@ -4,8 +4,11 @@ from ..operators import CaseInsensitiveComparator
 
 
 class EmailType(sa.types.TypeDecorator):
-    impl = sa.Unicode(255)
+    impl = sa.Unicode
     comparator_factory = CaseInsensitiveComparator
+
+    def __init__(self, length=255, *args, **kwargs):
+        super(EmailType, self).__init__(length=length, *args, **kwargs)
 
     def process_bind_param(self, value, dialect):
         if value is not None:

--- a/sqlalchemy_utils/types/encrypted.py
+++ b/sqlalchemy_utils/types/encrypted.py
@@ -13,7 +13,7 @@ try:
     import cryptography
     from cryptography.hazmat.backends import default_backend
     from cryptography.hazmat.primitives import hashes
-    from cryptography.hazmat.primitives.ciphers import(
+    from cryptography.hazmat.primitives.ciphers import (
         Cipher, algorithms, modes
     )
     from cryptography.fernet import Fernet

--- a/tests/types/test_email.py
+++ b/tests/types/test_email.py
@@ -10,6 +10,7 @@ def User(Base):
         __tablename__ = 'user'
         id = sa.Column(sa.Integer, primary_key=True)
         email = sa.Column(EmailType)
+        short_email = sa.Column(EmailType(length=70))
 
         def __repr__(self):
             return 'User(%r)' % self.id
@@ -30,3 +31,6 @@ class TestEmailType(object):
         clause = User.email == 'Someone@example.com'
         compiled = str(clause.compile(compile_kwargs={'literal_binds': True}))
         assert compiled == '"user".email = lower(\'Someone@example.com\')'
+
+    def test_custom_length(self, session, User):
+        assert User.short_email.type.impl.length == 70


### PR DESCRIPTION
Ticket #229.

This change allows users to specify the exact length the email field should have in database. By default the length is as it was before.