### PR TITLE
Feature/multi column observer

### DIFF
--- a/sqlalchemy_utils/observer.py
+++ b/sqlalchemy_utils/observer.py
@@ -158,7 +158,7 @@ from .functions import getdotattr, has_changes
 from .path import AttrPath
 from .utils import is_sequence
 
-Callback = namedtuple('Callback', ['func', 'path', 'backref', 'fullpath'])
+Callback = namedtuple('Callback', ['func', 'backref', 'fullpath'])
 
 
 class PropertyObserver(object):
@@ -215,7 +215,6 @@ class PropertyObserver(object):
                 self.callback_map[class_].append(
                     Callback(
                         func=callback,
-                        path=path,
                         backref=None,
                         fullpath=path
                     )
@@ -229,7 +228,6 @@ class PropertyObserver(object):
                         self.callback_map[prop_class].append(
                             Callback(
                                 func=callback,
-                                path=path[i:],
                                 backref=~ (path[:i]),
                                 fullpath=path
                             )

--- a/tests/observes/test_column_property.py
+++ b/tests/observes/test_column_property.py
@@ -58,3 +58,75 @@ class TestObservesForColumnWithoutActualChanges(object):
             product.price = 500
             session.commit()
         assert str(e.value) == 'Trying to change price'
+
+
+@pytest.mark.usefixtures('postgresql_dsn')
+class TestObservesForMultipleColumns(object):
+
+    @pytest.fixture
+    def Order(self, Base):
+        class Order(Base):
+            __tablename__ = 'order'
+            id = sa.Column(sa.Integer, primary_key=True)
+            unit_price = sa.Column(sa.Integer)
+            amount = sa.Column(sa.Integer)
+            total_price = sa.Column(sa.Integer)
+
+            @observes('amount', 'unit_price')
+            def total_price_observer(self, amount, unit_price):
+                self.total_price = amount * unit_price
+        return Order
+
+    @pytest.fixture
+    def init_models(self, Order):
+        pass
+
+    def test_only_notifies_observer_on_actual_changes(self, session, Order):
+        order = Order()
+        order.amount = 2
+        order.unit_price = 10
+        session.add(order)
+        session.flush()
+
+        order.amount = 1
+        session.flush()
+        assert order.total_price == 10
+
+        order.unit_price = 100
+        session.flush()
+        assert order.total_price == 100
+
+
+@pytest.mark.usefixtures('postgresql_dsn')
+class TestObservesForMultipleColumnsFiresOnlyOnce(object):
+
+    @pytest.fixture
+    def Order(self, Base):
+        class Order(Base):
+            __tablename__ = 'order'
+            id = sa.Column(sa.Integer, primary_key=True)
+            unit_price = sa.Column(sa.Integer)
+            amount = sa.Column(sa.Integer)
+
+            @observes('amount', 'unit_price')
+            def total_price_observer(self, amount, unit_price):
+                self.call_count = self.call_count + 1
+        return Order
+
+    @pytest.fixture
+    def init_models(self, Order):
+        pass
+
+    def test_only_notifies_observer_on_actual_changes(self, session, Order):
+        order = Order()
+        order.amount = 2
+        order.unit_price = 10
+        order.call_count = 0
+        session.add(order)
+        session.flush()
+        assert order.call_count == 1
+
+        order.amount = 1
+        order.unit_price = 100
+        session.flush()
+        assert order.call_count == 2


### PR DESCRIPTION
This PR adds support for multi column observers.

Things to consider:
 - Manually specifying `observer` to `observes` happens in a different way after this change. This can't be avoided with the chosen API as we support Python 2, that doesn't support [PEP 3102](https://www.python.org/dev/peps/pep-3102/).
 - Is there need for further documentation?
 - Is there need for further testing? If so, what should be tested?