### PR TITLE
Fix for bug #40 for Password type (only)

### DIFF
--- a/sqlalchemy_utils/types/password.py
+++ b/sqlalchemy_utils/types/password.py
@@ -169,6 +169,10 @@ class PasswordType(types.TypeDecorator, ScalarCoercible):
 
         return self._max_length
 
+    def __repr__(self):
+        # Ensure representation uses max_length, not length
+        return "PasswordType(max_length=%r)" % self.length
+
     def calculate_max_length(self):
         # Calculate the largest possible encoded password.
         # name + rounds + salt + hash + ($ * 4) of largest hash


### PR DESCRIPTION
Fix makes representation consistent with constructor call by printing
length as the expected max_length parameter. Note this helps downstream
alembic migrations work properly too.
