### PR TITLE
Added support for backref tuple to auto_delete_orphans

### DIFF
--- a/sqlalchemy_utils/listeners.py
+++ b/sqlalchemy_utils/listeners.py
@@ -227,6 +227,8 @@ def auto_delete_orphans(attr):
             'The relationship argument given for auto_delete_orphans needs to '
             'have a backref relationship set.'
         )
+    if isinstance(backref, tuple):
+        backref = backref[0]
 
     @sa.event.listens_for(sa.orm.Session, 'after_flush')
     def delete_orphan_listener(session, ctx):
@@ -249,7 +251,7 @@ def auto_delete_orphans(attr):
             (
                 session.query(target_class)
                 .filter(
-                    ~getattr(target_class, attr.property.backref).any()
+                    ~getattr(target_class, backref).any()
                 )
                 .delete(synchronize_session=False)
             )

--- a/tests/test_auto_delete_orphans.py
+++ b/tests/test_auto_delete_orphans.py
@@ -37,17 +37,17 @@ def Tag(Base):
     return Tag
 
 
-@pytest.fixture
-def Entry(Base, Tag, tagging_tbl):
+@pytest.fixture(params=['entries', backref('entries', lazy='select')], ids=['backref_string', 'backref_with_keywords'])
+def Entry(Base, Tag, tagging_tbl, request):
     class Entry(Base):
         __tablename__ = 'entry'
 
         id = sa.Column(sa.Integer, primary_key=True)
 
         tags = sa.orm.relationship(
-            'Tag',
+            Tag,
             secondary=tagging_tbl,
-            backref='entries'
+            backref=request.param
         )
     auto_delete_orphans(Entry.tags)
     return Entry
@@ -61,26 +61,10 @@ def EntryWithoutTagsBackref(Base, Tag, tagging_tbl):
         id = sa.Column(sa.Integer, primary_key=True)
 
         tags = sa.orm.relationship(
-            'Tag',
+            Tag,
             secondary=tagging_tbl
         )
     return EntryWithoutTagsBackref
-
-
-@pytest.fixture
-def EntryWithBackrefKeywords(Base, Tag, tagging_tbl):
-    class Entry(Base):
-        __tablename__ = 'entry'
-
-        id = sa.Column(sa.Integer, primary_key=True)
-
-        tags = sa.orm.relationship(
-            'Tag',
-            secondary=tagging_tbl,
-            backref=backref('entries', lazy='select')
-        )
-    auto_delete_orphans(Entry.tags)
-    return Entry
 
 
 class TestAutoDeleteOrphans(object):
@@ -123,34 +107,3 @@ class TestAutoDeleteOrphansWithoutBackref(object):
     def test_orphan_deletion(self, EntryWithoutTagsBackref):
         with pytest.raises(ImproperlyConfigured):
             auto_delete_orphans(EntryWithoutTagsBackref.tags)
-
-
-class TestAutoDeleteOrphansBackrefWithKeywords(object):
-
-    @pytest.fixture
-    def init_models(self, EntryWithBackrefKeywords, Tag):
-        pass
-
-    def test_orphan_deletion(self, session, EntryWithBackrefKeywords, Tag):
-        r1 = EntryWithBackrefKeywords()
-        r2 = EntryWithBackrefKeywords()
-        r3 = EntryWithBackrefKeywords()
-        t1, t2, t3, t4 = (
-            Tag('t1'),
-            Tag('t2'),
-            Tag('t3'),
-            Tag('t4')
-        )
-
-        r1.tags.extend([t1, t2])
-        r2.tags.extend([t2, t3])
-        r3.tags.extend([t4])
-        session.add_all([r1, r2, r3])
-
-        assert session.query(Tag).count() == 4
-        r2.tags.remove(t2)
-        assert session.query(Tag).count() == 4
-        r1.tags.remove(t2)
-        assert session.query(Tag).count() == 3
-        r1.tags.remove(t1)
-        assert session.query(Tag).count() == 2

--- a/tests/test_auto_delete_orphans.py
+++ b/tests/test_auto_delete_orphans.py
@@ -37,7 +37,8 @@ def Tag(Base):
     return Tag
 
 
-@pytest.fixture(params=['entries', backref('entries', lazy='select')], ids=['backref_string', 'backref_with_keywords'])
+@pytest.fixture(params=['entries', backref('entries', lazy='select')],
+                ids=['backref_string', 'backref_with_keywords'])
 def Entry(Base, Tag, tagging_tbl, request):
     class Entry(Base):
         __tablename__ = 'entry'


### PR DESCRIPTION
When using `sqlalchemy.orm.backref` it returns a tuple.