### PR TITLE
postgres connection url not being parsed correctly 

### DIFF
--- a/sqlalchemy_utils/functions/database.py
+++ b/sqlalchemy_utils/functions/database.py
@@ -453,8 +453,8 @@ def database_exists(url):
 
     url = copy(make_url(url))
     database = url.database
-    if url.drivername.startswith('postgresql'):
-        url.database = 'template1'
+    if url.drivername.startswith('postgresql') or url.drivername.startswith('postgres'):
+        url.database = database
     else:
         url.database = None
 


### PR DESCRIPTION
postgres url parsing is removing the database from the url which cause problems when using the server url + "/databasename" method of connecting

it is also only an issue when using the "postgres" head of the connection string because this check only looks for the version "postgresql"

I have updated the url.database to be the database that is parsed from the URL that way the check exist function isn't looking at the "template1" database which the server running this script may not have access to read.

after reading postgres docs connecting to template1 makes sense. Looking into other ways since my current  situation disallows me to connect to template1.