### PR TITLE
TimeZoneType support for static timezones

### DIFF
--- a/sqlalchemy_utils/types/timezone.py
+++ b/sqlalchemy_utils/types/timezone.py
@@ -52,9 +52,10 @@ class TimezoneType(types.TypeDecorator, ScalarCoercible):
 
         elif backend == 'pytz':
             try:
-                from pytz import tzfile, timezone
+                from pytz import timezone
+                from pytz.tzinfo import BaseTzInfo
 
-                self.python_type = tzfile.DstTzInfo
+                self.python_type = BaseTzInfo
                 self._to = timezone
                 self._from = six.text_type
 
@@ -71,13 +72,11 @@ class TimezoneType(types.TypeDecorator, ScalarCoercible):
             )
 
     def _coerce(self, value):
-        if value and not isinstance(value, self.python_type):
+        if value is not None and not isinstance(value, self.python_type):
             obj = self._to(value)
             if obj is None:
                 raise ValueError("unknown time zone '%s'" % value)
-
             return obj
-
         return value
 
     def process_bind_param(self, value, dialect):


### PR DESCRIPTION
It turns out some strange time zones aren't instances of `DstTzInfo` but of `StaticTzInfo`. It appears the `pytz` library uses these two classes interchangeably depending on whether they support daylight savings time. Looks like there's a `BaseTzInfo` we can use that both of these inherit from.

First commit should fail (contains the test case confirming the bug, but does not contain the patch), second commit with the fix should pass.

See this failed build for the issue this fixes:
https://travis-ci.org/kvesteri/sqlalchemy-utils/jobs/162467324

Here are all the test cases this checks:

``` python
tests/types/test_timezone.py::TestTimezoneType::test_parameter_processing PASSED
tests/types/test_timezone.py::test_can_coerce_pytz_DstTzInfo PASSED
tests/types/test_timezone.py::test_can_coerce_pytz_StaticTzInfo PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Abidjan] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Accra] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Addis_Ababa] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Algiers] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Asmara] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Asmera] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Bamako] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Bangui] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Banjul] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Bissau] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Blantyre] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Brazzaville] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Bujumbura] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Cairo] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Casablanca] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Ceuta] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Conakry] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Dakar] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Dar_es_Salaam] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Djibouti] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Douala] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/El_Aaiun] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Freetown] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Gaborone] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Harare] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Johannesburg] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Juba] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Kampala] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Khartoum] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Kigali] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Kinshasa] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Lagos] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Libreville] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Lome] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Luanda] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Lubumbashi] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Lusaka] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Malabo] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Maputo] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Maseru] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Mbabane] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Mogadishu] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Monrovia] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Nairobi] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Ndjamena] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Niamey] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Nouakchott] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Ouagadougou] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Porto-Novo] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Sao_Tome] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Timbuktu] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Tripoli] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Tunis] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Africa/Windhoek] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Adak] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Anchorage] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Anguilla] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Antigua] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Araguaina] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Argentina/Buenos_Aires] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Argentina/Catamarca] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Argentina/ComodRivadavia] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Argentina/Cordoba] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Argentina/Jujuy] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Argentina/La_Rioja] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Argentina/Mendoza] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Argentina/Rio_Gallegos] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Argentina/Salta] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Argentina/San_Juan] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Argentina/San_Luis] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Argentina/Tucuman] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Argentina/Ushuaia] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Aruba] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Asuncion] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Atikokan] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Atka] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Bahia] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Bahia_Banderas] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Barbados] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Belem] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Belize] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Blanc-Sablon] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Boa_Vista] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Bogota] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Boise] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Buenos_Aires] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Cambridge_Bay] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Campo_Grande] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Cancun] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Caracas] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Catamarca] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Cayenne] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Cayman] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Chicago] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Chihuahua] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Coral_Harbour] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Cordoba] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Costa_Rica] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Creston] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Cuiaba] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Curacao] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Danmarkshavn] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Dawson] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Dawson_Creek] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Denver] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Detroit] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Dominica] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Edmonton] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Eirunepe] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/El_Salvador] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Ensenada] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Fort_Nelson] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Fort_Wayne] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Fortaleza] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Glace_Bay] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Godthab] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Goose_Bay] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Grand_Turk] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Grenada] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Guadeloupe] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Guatemala] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Guayaquil] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Guyana] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Halifax] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Havana] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Hermosillo] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Indiana/Indianapolis] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Indiana/Knox] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Indiana/Marengo] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Indiana/Petersburg] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Indiana/Tell_City] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Indiana/Vevay] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Indiana/Vincennes] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Indiana/Winamac] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Indianapolis] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Inuvik] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Iqaluit] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Jamaica] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Jujuy] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Juneau] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Kentucky/Louisville] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Kentucky/Monticello] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Knox_IN] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Kralendijk] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/La_Paz] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Lima] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Los_Angeles] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Louisville] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Lower_Princes] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Maceio] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Managua] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Manaus] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Marigot] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Martinique] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Matamoros] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Mazatlan] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Mendoza] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Menominee] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Merida] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Metlakatla] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Mexico_City] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Miquelon] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Moncton] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Monterrey] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Montevideo] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Montreal] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Montserrat] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Nassau] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/New_York] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Nipigon] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Nome] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Noronha] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/North_Dakota/Beulah] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/North_Dakota/Center] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/North_Dakota/New_Salem] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Ojinaga] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Panama] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Pangnirtung] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Paramaribo] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Phoenix] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Port-au-Prince] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Port_of_Spain] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Porto_Acre] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Porto_Velho] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Puerto_Rico] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Rainy_River] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Rankin_Inlet] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Recife] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Regina] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Resolute] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Rio_Branco] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Rosario] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Santa_Isabel] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Santarem] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Santiago] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Santo_Domingo] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Sao_Paulo] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Scoresbysund] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Shiprock] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Sitka] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/St_Barthelemy] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/St_Johns] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/St_Kitts] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/St_Lucia] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/St_Thomas] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/St_Vincent] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Swift_Current] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Tegucigalpa] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Thule] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Thunder_Bay] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Tijuana] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Toronto] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Tortola] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Vancouver] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Virgin] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Whitehorse] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Winnipeg] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Yakutat] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[America/Yellowknife] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Antarctica/Casey] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Antarctica/Davis] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Antarctica/DumontDUrville] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Antarctica/Macquarie] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Antarctica/Mawson] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Antarctica/McMurdo] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Antarctica/Palmer] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Antarctica/Rothera] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Antarctica/South_Pole] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Antarctica/Syowa] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Antarctica/Troll] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Antarctica/Vostok] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Arctic/Longyearbyen] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Aden] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Almaty] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Amman] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Anadyr] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Aqtau] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Aqtobe] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Ashgabat] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Ashkhabad] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Baghdad] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Bahrain] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Baku] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Bangkok] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Barnaul] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Beirut] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Bishkek] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Brunei] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Calcutta] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Chita] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Choibalsan] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Chongqing] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Chungking] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Colombo] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Dacca] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Damascus] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Dhaka] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Dili] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Dubai] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Dushanbe] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Gaza] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Harbin] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Hebron] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Ho_Chi_Minh] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Hong_Kong] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Hovd] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Irkutsk] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Istanbul] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Jakarta] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Jayapura] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Jerusalem] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Kabul] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Kamchatka] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Karachi] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Kashgar] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Kathmandu] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Katmandu] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Khandyga] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Kolkata] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Krasnoyarsk] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Kuala_Lumpur] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Kuching] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Kuwait] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Macao] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Macau] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Magadan] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Makassar] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Manila] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Muscat] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Nicosia] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Novokuznetsk] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Novosibirsk] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Omsk] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Oral] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Phnom_Penh] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Pontianak] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Pyongyang] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Qatar] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Qyzylorda] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Rangoon] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Riyadh] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Saigon] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Sakhalin] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Samarkand] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Seoul] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Shanghai] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Singapore] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Srednekolymsk] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Taipei] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Tashkent] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Tbilisi] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Tehran] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Tel_Aviv] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Thimbu] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Thimphu] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Tokyo] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Tomsk] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Ujung_Pandang] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Ulaanbaatar] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Ulan_Bator] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Urumqi] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Ust-Nera] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Vientiane] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Vladivostok] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Yakutsk] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Yekaterinburg] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Asia/Yerevan] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Atlantic/Azores] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Atlantic/Bermuda] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Atlantic/Canary] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Atlantic/Cape_Verde] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Atlantic/Faeroe] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Atlantic/Faroe] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Atlantic/Jan_Mayen] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Atlantic/Madeira] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Atlantic/Reykjavik] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Atlantic/South_Georgia] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Atlantic/St_Helena] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Atlantic/Stanley] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Australia/ACT] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Australia/Adelaide] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Australia/Brisbane] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Australia/Broken_Hill] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Australia/Canberra] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Australia/Currie] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Australia/Darwin] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Australia/Eucla] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Australia/Hobart] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Australia/LHI] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Australia/Lindeman] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Australia/Lord_Howe] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Australia/Melbourne] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Australia/NSW] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Australia/North] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Australia/Perth] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Australia/Queensland] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Australia/South] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Australia/Sydney] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Australia/Tasmania] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Australia/Victoria] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Australia/West] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Australia/Yancowinna] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Brazil/Acre] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Brazil/DeNoronha] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Brazil/East] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Brazil/West] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[CET] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[CST6CDT] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Canada/Atlantic] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Canada/Central] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Canada/East-Saskatchewan] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Canada/Eastern] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Canada/Mountain] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Canada/Newfoundland] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Canada/Pacific] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Canada/Saskatchewan] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Canada/Yukon] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Chile/Continental] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Chile/EasterIsland] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Cuba] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[EET] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[EST] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[EST5EDT] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Egypt] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Eire] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Etc/GMT] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Etc/GMT+0] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Etc/GMT+1] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Etc/GMT+10] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Etc/GMT+11] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Etc/GMT+12] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Etc/GMT+2] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Etc/GMT+3] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Etc/GMT+4] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Etc/GMT+5] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Etc/GMT+6] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Etc/GMT+7] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Etc/GMT+8] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Etc/GMT+9] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Etc/GMT-0] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Etc/GMT-1] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Etc/GMT-10] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Etc/GMT-11] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Etc/GMT-12] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Etc/GMT-13] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Etc/GMT-14] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Etc/GMT-2] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Etc/GMT-3] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Etc/GMT-4] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Etc/GMT-5] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Etc/GMT-6] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Etc/GMT-7] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Etc/GMT-8] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Etc/GMT-9] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Etc/GMT0] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Etc/Greenwich] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Etc/UCT] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Etc/UTC] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Etc/Universal] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Etc/Zulu] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Amsterdam] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Andorra] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Astrakhan] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Athens] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Belfast] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Belgrade] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Berlin] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Bratislava] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Brussels] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Bucharest] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Budapest] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Busingen] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Chisinau] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Copenhagen] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Dublin] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Gibraltar] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Guernsey] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Helsinki] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Isle_of_Man] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Istanbul] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Jersey] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Kaliningrad] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Kiev] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Kirov] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Lisbon] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Ljubljana] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/London] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Luxembourg] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Madrid] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Malta] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Mariehamn] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Minsk] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Monaco] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Moscow] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Nicosia] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Oslo] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Paris] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Podgorica] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Prague] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Riga] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Rome] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Samara] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/San_Marino] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Sarajevo] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Simferopol] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Skopje] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Sofia] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Stockholm] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Tallinn] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Tirane] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Tiraspol] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Ulyanovsk] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Uzhgorod] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Vaduz] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Vatican] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Vienna] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Vilnius] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Volgograd] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Warsaw] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Zagreb] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Zaporozhye] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Europe/Zurich] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[GB] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[GB-Eire] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[GMT] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[GMT+0] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[GMT-0] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[GMT0] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Greenwich] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[HST] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Hongkong] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Iceland] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Indian/Antananarivo] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Indian/Chagos] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Indian/Christmas] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Indian/Cocos] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Indian/Comoro] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Indian/Kerguelen] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Indian/Mahe] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Indian/Maldives] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Indian/Mauritius] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Indian/Mayotte] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Indian/Reunion] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Iran] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Israel] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Jamaica] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Japan] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Kwajalein] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Libya] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[MET] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[MST] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[MST7MDT] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Mexico/BajaNorte] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Mexico/BajaSur] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Mexico/General] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[NZ] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[NZ-CHAT] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Navajo] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[PRC] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[PST8PDT] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Apia] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Auckland] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Bougainville] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Chatham] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Chuuk] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Easter] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Efate] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Enderbury] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Fakaofo] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Fiji] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Funafuti] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Galapagos] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Gambier] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Guadalcanal] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Guam] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Honolulu] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Johnston] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Kiritimati] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Kosrae] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Kwajalein] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Majuro] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Marquesas] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Midway] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Nauru] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Niue] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Norfolk] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Noumea] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Pago_Pago] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Palau] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Pitcairn] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Pohnpei] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Ponape] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Port_Moresby] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Rarotonga] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Saipan] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Samoa] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Tahiti] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Tarawa] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Tongatapu] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Truk] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Wake] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Wallis] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Pacific/Yap] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Poland] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Portugal] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[ROC] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[ROK] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Singapore] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Turkey] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[UCT] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[US/Alaska] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[US/Aleutian] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[US/Arizona] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[US/Central] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[US/East-Indiana] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[US/Eastern] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[US/Hawaii] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[US/Indiana-Starke] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[US/Michigan] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[US/Mountain] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[US/Pacific] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[US/Pacific-New] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[US/Samoa] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[UTC] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Universal] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[W-SU] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[WET] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_pytz_zone[Zulu] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Antarctica/Mawson] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[US/Central] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Bamako] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Minsk] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Antarctica/South_Pole] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Edmonton] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Bratislava] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[US/Indiana-Starke] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[MET] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Rarotonga] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Ashgabat] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Beirut] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Australia/Brisbane] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Santarem] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Athens] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Kirov] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[GB] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[MST7MDT] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Grand_Turk] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Antarctica/Syowa] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Barnaul] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Kiritimati] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Lower_Princes] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Santa_Isabel] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Argentina/San_Luis] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Brazil/DeNoronha] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Israel] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Andorra] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Lubumbashi] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Antarctica/Palmer] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Nouakchott] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Campo_Grande] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Paris] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Port_of_Spain] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Vladivostok] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Canada/Mountain] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[US/East-Indiana] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Indiana/Knox] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Conakry] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Indian/Mahe] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Australia/NSW] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Etc/GMT-3] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Thule] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Blantyre] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Malabo] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Argentina/Jujuy] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Detroit] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Etc/Greenwich] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Ujung_Pandang] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Australia/Perth] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Fort_Wayne] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[PST8PDT] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Fortaleza] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Sao_Tome] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Goose_Bay] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Dominica] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Costa_Rica] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Vienna] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Rome] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Etc/GMT-4] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Indian/Antananarivo] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Whitehorse] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[UCT] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Rio_Branco] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Pohnpei] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Indiana/Indianapolis] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Tbilisi] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Mendoza] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/London] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Inuvik] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Damascus] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Yerevan] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Tashkent] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Dubai] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Los_Angeles] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Tomsk] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Urumqi] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Tarawa] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Libya] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Australia/Yancowinna] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Adak] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[MST] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Eirunepe] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Tegucigalpa] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Atlantic/Cape_Verde] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Tiraspol] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Etc/GMT+1] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[WET] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Canada/Yukon] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Indiana/Tell_City] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Moncton] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Timbuktu] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Dakar] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Ponape] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Etc/GMT-11] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Lome] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Khartoum] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Blanc-Sablon] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Yap] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Argentina/Tucuman] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Simferopol] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Oral] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Wake] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Ust-Nera] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[UTC] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Arctic/Longyearbyen] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Glace_Bay] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Etc/GMT-5] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Magadan] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Bangkok] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Kuwait] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Argentina/ComodRivadavia] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/St_Vincent] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Canada/Atlantic] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Nome] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Antarctica/Vostok] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Winnipeg] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Jersey] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Atlantic/Jan_Mayen] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Shiprock] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Dacca] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Gambier] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Virgin] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Australia/Canberra] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Atlantic/Madeira] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Puerto_Rico] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Antarctica/Davis] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Recife] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Yekaterinburg] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Nipigon] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Monrovia] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Almaty] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Guatemala] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Argentina/San_Juan] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Samara] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Yakutsk] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Juba] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Jamaica] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Gibraltar] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Tunis] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Indian/Kerguelen] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Bucharest] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Curacao] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Taipei] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Mexico/BajaNorte] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Indian/Mayotte] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Thunder_Bay] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Midway] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Godthab] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Danmarkshavn] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Anadyr] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Astrakhan] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Mexico_City] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Chihuahua] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Tallinn] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Atlantic/Stanley] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Enderbury] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Rangoon] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Manaus] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Catamarca] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Atikokan] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Canada/Newfoundland] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Swift_Current] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Accra] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Yakutat] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Cayenne] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[US/Eastern] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Skopje] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Casablanca] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Cuba] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Volgograd] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Jayapura] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Turkey] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Brazil/West] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Ulan_Bator] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Etc/GMT-1] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Easter] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Etc/GMT+10] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Uzhgorod] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Halifax] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Pyongyang] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Aruba] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Asmera] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Chita] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Kathmandu] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Rankin_Inlet] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Australia/Broken_Hill] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Chungking] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Karachi] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Australia/ACT] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Kwajalein] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Hovd] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Atlantic/Bermuda] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Australia/Lindeman] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[US/Arizona] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Atlantic/Faeroe] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[EST] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Australia/Darwin] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Lusaka] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Dhaka] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Apia] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Universal] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Tel_Aviv] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Vaduz] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Niamey] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Bahia] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Japan] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Etc/GMT+12] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Nauru] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Guadeloupe] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Bougainville] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Antarctica/Macquarie] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Toronto] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Nassau] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Budapest] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Antarctica/McMurdo] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Etc/UCT] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Sofia] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Kinshasa] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/El_Aaiun] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Havana] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Berlin] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Montserrat] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Rosario] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Managua] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Hanoi] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Panama] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Etc/GMT-12] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Kaliningrad] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Maputo] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Ljubljana] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Banjul] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Qyzylorda] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Etc/GMT+2] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Pontianak] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Majuro] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Kralendijk] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[ROK] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Mbabane] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Metlakatla] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[US/Samoa] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Etc/GMT-10] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Lagos] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Kampala] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[NZ-CHAT] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Etc/GMT+3] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Irkutsk] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Etc/GMT] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Barbados] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Argentina/La_Rioja] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Paramaribo] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Dawson_Creek] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Merida] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Vientiane] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Luanda] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Australia/Currie] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Montreal] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Fakaofo] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Etc/GMT+9] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Cordoba] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[US/Mountain] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Dili] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Australia/LHI] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Kentucky/Monticello] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Choibalsan] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Australia/Queensland] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Calcutta] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Yellowknife] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Australia/Hobart] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Ashkhabad] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[US/Hawaii] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Istanbul] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Ho_Chi_Minh] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Samarkand] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Samoa] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Creston] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Antarctica/Casey] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Jakarta] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Copenhagen] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Etc/GMT+4] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Etc/GMT-7] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/North_Dakota/Center] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Tirane] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Argentina/Rio_Gallegos] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Freetown] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Antarctica/Troll] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Busingen] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/St_Thomas] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[GMT-0] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Antarctica/DumontDUrville] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Indian/Comoro] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Aden] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Maceio] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Zaporozhye] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Pitcairn] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Jamaica] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Zulu] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Brazil/East] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Ouagadougou] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Australia/North] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Cancun] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Atlantic/South_Georgia] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[US/Pacific] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Santiago] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Anchorage] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Dublin] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Macao] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Canada/Eastern] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Efate] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Denver] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Brunei] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Gaborone] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Colombo] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Juneau] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/St_Johns] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Noronha] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Port_Moresby] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Novokuznetsk] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Belgrade] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Shanghai] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Atlantic/Faroe] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/St_Barthelemy] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Chuuk] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[GB-Eire] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Amman] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Australia/Lord_Howe] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Kentucky/Louisville] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[US/Pacific-New] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/North_Dakota/Beulah] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Atlantic/Azores] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Cambridge_Bay] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Baku] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Harare] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Coral_Harbour] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Etc/GMT0] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Kashgar] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Vatican] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[GMT+0] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/North_Dakota/New_Salem] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Muscat] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Knox_IN] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Australia/West] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Sao_Paulo] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Libreville] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Canada/Saskatchewan] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Boa_Vista] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Helsinki] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Mogadishu] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Mazatlan] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Aqtau] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Singapore] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Atka] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Caracas] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Australia/Adelaide] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Iqaluit] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Factory] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[W-SU] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Argentina/Salta] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Iran] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Bangui] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Etc/GMT+5] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Bujumbura] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Kosrae] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Tijuana] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Argentina/Catamarca] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[EET] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Fort_Nelson] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[HST] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Luxembourg] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Chicago] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Ulyanovsk] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Zagreb] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Ojinaga] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Seoul] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Chisinau] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[US/Michigan] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Chile/EasterIsland] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Porto_Velho] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[US/Aleutian] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Argentina/Ushuaia] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Srednekolymsk] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Buenos_Aires] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Dushanbe] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Johannesburg] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Monaco] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Kuching] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/El_Salvador] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Sarajevo] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Algiers] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Etc/GMT-14] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Nicosia] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Marquesas] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Argentina/Mendoza] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Douala] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Indian/Mauritius] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Argentina/Buenos_Aires] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Norfolk] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Cayman] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Regina] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Djibouti] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Atlantic/St_Helena] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Pago_Pago] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Tehran] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Argentina/Cordoba] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[CET] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Truk] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[NZ] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Santo_Domingo] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Porto_Acre] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Etc/GMT-13] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Canada/East-Saskatchewan] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Phnom_Penh] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Dawson] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Kuala_Lumpur] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Chatham] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Australia/Melbourne] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Rainy_River] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Vancouver] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[GMT0] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Atlantic/Reykjavik] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Indiana/Vevay] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Madrid] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Indian/Maldives] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Hong_Kong] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Nicosia] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Indiana/Marengo] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Stockholm] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Miquelon] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[ROC] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Guadalcanal] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Thimbu] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Greenwich] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Tortola] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Etc/GMT+0] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Phoenix] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Malta] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Singapore] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Kolkata] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/La_Paz] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Nairobi] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Indian/Christmas] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Qatar] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Noumea] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Ulaanbaatar] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Manila] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Etc/Zulu] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Indiana/Vincennes] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Australia/Victoria] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Chile/Continental] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Hermosillo] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Windhoek] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Guernsey] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Warsaw] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Indian/Cocos] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Gaza] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Etc/GMT-8] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Etc/GMT+11] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Etc/GMT-0] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Boise] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Iceland] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Asuncion] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Tahiti] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Ndjamena] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Riyadh] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[CST6CDT] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Anguilla] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Indian/Chagos] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Grenada] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Indianapolis] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Kiev] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Marigot] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Chongqing] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Honolulu] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Ensenada] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Moscow] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Novosibirsk] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Addis_Ababa] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Sakhalin] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Cairo] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Zurich] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Monterrey] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Saigon] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Port-au-Prince] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Jerusalem] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Amsterdam] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Riga] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Makassar] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Belize] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Mexico/BajaSur] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Baghdad] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Hebron] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Krasnoyarsk] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/San_Marino] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[GMT] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Belem] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Canada/Central] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Indiana/Petersburg] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Auckland] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Hongkong] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Wallis] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Aqtobe] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Prague] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Harbin] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[EST5EDT] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Galapagos] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Menominee] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Pangnirtung] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Bogota] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Etc/GMT+6] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Lisbon] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Guayaquil] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Scoresbysund] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Etc/UTC] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Johnston] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Etc/Universal] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Etc/GMT-6] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Podgorica] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Asmara] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Tongatapu] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Funafuti] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Bishkek] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Sitka] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Australia/Sydney] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Lima] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Etc/GMT-9] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Katmandu] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/New_York] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Ceuta] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Istanbul] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Antarctica/Rothera] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Tokyo] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Montevideo] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Canada/Pacific] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Khandyga] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Mariehamn] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Bahia_Banderas] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Palau] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Matamoros] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Kwajalein] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Resolute] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Etc/GMT-2] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/St_Kitts] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Bahrain] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Guam] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Kamchatka] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Tripoli] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Thimphu] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Saipan] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Cuiaba] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Maseru] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Australia/Tasmania] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Atlantic/Canary] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Araguaina] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Brussels] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Portugal] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Oslo] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Kabul] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Etc/GMT+7] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Martinique] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Poland] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Macau] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Niue] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Isle_of_Man] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Abidjan] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Navajo] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Bissau] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Eire] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Vilnius] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Jujuy] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Porto-Novo] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Mexico/General] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Antigua] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Brazil/Acre] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Australia/Eucla] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Indian/Reunion] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Brazzaville] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Louisville] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Egypt] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Kigali] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/St_Lucia] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Asia/Omsk] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Etc/GMT+8] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Africa/Dar_es_Salaam] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Australia/South] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[PRC] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Pacific/Fiji] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[Europe/Belfast] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Indiana/Winamac] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[America/Guyana] PASSED
tests/types/test_timezone.py::test_can_coerce_string_for_dateutil_zone[US/Alaska] PASSED
tests/types/test_timezone.py::test_can_coerce_and_raise_UnknownTimeZoneError_or_ValueError[dateutil] PASSED
tests/types/test_timezone.py::test_can_coerce_and_raise_UnknownTimeZoneError_or_ValueError[pytz] PASSED
tests/types/test_timezone.py::test_can_coerce_None[dateutil] PASSED
tests/types/test_timezone.py::test_can_coerce_None[pytz] PASSED

========================= 1185 passed in 2.92 seconds ==========================
```
