### PR TITLE
PhoneNumberType().python_type should be a class

### DIFF
--- a/sqlalchemy_utils/types/phone_number.py
+++ b/sqlalchemy_utils/types/phone_number.py
@@ -154,8 +154,9 @@ class PhoneNumberType(types.TypeDecorator, ScalarCoercible):
     STORE_FORMAT = 'e164'
     impl = types.Unicode(20)
 
-    def python_type(self, text):
-        return self._coerce(text)
+    @property
+    def python_type(self):
+        return PhoneNumber
 
     def __init__(self, region='US', max_length=20, *args, **kwargs):
         # Bail if phonenumbers is not found.

--- a/tests/types/test_phonenumber.py
+++ b/tests/types/test_phonenumber.py
@@ -171,6 +171,10 @@ class TestPhoneNumberType(object):
 
         assert isinstance(user.phone_number, PhoneNumber)
 
+    def test_can_get_python_type(self):
+        pn_type = PhoneNumberType()
+        assert pn_type.python_type is PhoneNumber
+
 
 @pytest.mark.skipif('types.phone_number.phonenumbers is None')
 class TestPhoneNumberComposite(object):


### PR DESCRIPTION
See:
http://docs.sqlalchemy.org/en/latest/core/type_api.html#sqlalchemy.types.TypeEngine.python_type

I found this as a result of a change introduced in marshmallow-sqlalchemy https://github.com/kelvinhammond/marshmallow-sqlalchemy/commit/12da838c8ca3e02516dd83852cef870d1d596b1b