### PR TITLE
Added SQLite support for PasswordType

### DIFF
--- a/sqlalchemy_utils/types/password.py
+++ b/sqlalchemy_utils/types/password.py
@@ -2,7 +2,7 @@ import weakref
 
 import six
 from sqlalchemy import types
-from sqlalchemy.dialects import oracle, postgresql
+from sqlalchemy.dialects import oracle, postgresql, sqlite
 from sqlalchemy.ext.mutable import Mutable
 
 from ..exceptions import ImproperlyConfigured
@@ -192,14 +192,15 @@ class PasswordType(types.TypeDecorator, ScalarCoercible):
         if dialect.name == 'postgresql':
             # Use a BYTEA type for postgresql.
             impl = postgresql.BYTEA(self.length)
-            return dialect.type_descriptor(impl)
-        if dialect.name == 'oracle':
+        elif dialect.name == 'oracle':
             # Use a RAW type for oracle.
             impl = oracle.RAW(self.length)
-            return dialect.type_descriptor(impl)
-
-        # Use a VARBINARY for all other dialects.
-        impl = types.VARBINARY(self.length)
+        elif dialect.name == 'sqlite':
+            # Use a BLOB type for sqlite
+            impl = sqlite.BLOB(self.length)
+        else:
+            # Use a VARBINARY for all other dialects.
+            impl = types.VARBINARY(self.length)
         return dialect.type_descriptor(impl)
 
     def process_bind_param(self, value, dialect):


### PR DESCRIPTION
This change fixes the issue of column type mismatch on SQLite as `VARBINARY` type fallbacks to `NUMERIC`, and in the end, Alembic always detects changes in my project:

```
Detected type change from NUMERIC(precision=128) to PasswordType(max_length=128) on 'user.password'
```

According to [this reply on SQLAlchemy support forum](https://groups.google.com/forum/#!topic/sqlalchemy/GpkSJ0XUgwo), `sa.VARBINARY` is not a good fallback, but I have no idea on how would a correct implementation look like, so I only added SQLite support.

Originally, I thought my problem is reported in #106, but it turned out to be another not quite closely related issue.

#233 is another enhancement for PasswordType, which, in fact, solves #106.