### PR TITLE
Fix a DeprecationWarning by using LargeBinary instead of Binary

### DIFF
--- a/sqlalchemy_utils/types/encrypted.py
+++ b/sqlalchemy_utils/types/encrypted.py
@@ -3,7 +3,7 @@ import base64
 import datetime
 
 import six
-from sqlalchemy.types import Binary, String, TypeDecorator
+from sqlalchemy.types import LargeBinary, String, TypeDecorator
 
 from ..exceptions import ImproperlyConfigured
 from .scalar_coercible import ScalarCoercible
@@ -199,7 +199,7 @@ class EncryptedType(TypeDecorator, ScalarCoercible):
 
     """
 
-    impl = Binary
+    impl = LargeBinary
 
     def __init__(self, type_in=None, key=None, engine=None, **kwargs):
         """Initialization."""


### PR DESCRIPTION
The `Binary` type has been renamed to `LargeBinary` quite a while ago: https://bitbucket.org/zzzeek/sqlalchemy/commits/fc92d14bbe3077ff94df108bf53ec77e0da83dd8