### PR TITLE
Handle better the datetimes for EncryptedType

### DIFF
--- a/tests/types/test_encrypted.py
+++ b/tests/types/test_encrypted.py
@@ -4,7 +4,11 @@ import pytest
 import sqlalchemy as sa
 
 from sqlalchemy_utils import ColorType, EncryptedType, PhoneNumberType
-from sqlalchemy_utils.types.encrypted import AesEngine, FernetEngine
+from sqlalchemy_utils.types.encrypted import (
+    AesEngine,
+    DatetimeHandler,
+    FernetEngine
+)
 
 cryptography = None
 try:
@@ -119,7 +123,7 @@ def user_time():
 
 @pytest.fixture
 def user_datetime():
-    return datetime(2010, 10, 2, 10, 12)
+    return datetime(2010, 10, 2, 10, 12, 45, 2334)
 
 
 @pytest.fixture
@@ -175,6 +179,38 @@ def user(
     session.commit()
 
     return session.query(User).get(user.id)
+
+
+@pytest.fixture
+def datetime_with_micro_and_timezone():
+    import pytz
+    tz = pytz.timezone('Pacific/Tahiti')
+    return datetime(2017, 8, 21, 4, 26, 36, 523010, tzinfo=tz)
+
+
+@pytest.fixture
+def datetime_with_micro():
+    return datetime(2017, 8, 21, 10, 12, 45, 22)
+
+
+@pytest.fixture
+def datetime_simple():
+    return datetime(2017, 8, 21, 10, 12, 45)
+
+
+@pytest.fixture
+def time_with_micro():
+    return time(10, 12, 45, 22)
+
+
+@pytest.fixture
+def time_simple():
+    return time(10, 12, 45)
+
+
+@pytest.fixture
+def date_simple():
+    return date(2017, 8, 21)
 
 
 @pytest.mark.skipif('cryptography is None')
@@ -295,3 +331,66 @@ class TestFernetEncryptedTypeTestCase(EncryptedTypeTestCase):
     @pytest.fixture
     def encryption_engine(self):
         return FernetEngine
+
+
+class TestDatetimeHandler(object):
+
+    def test_datetime_with_micro_and_timezone(self):
+        original_datetime = datetime_with_micro_and_timezone()
+        original_datetime_isoformat = original_datetime.isoformat()
+        python_type = datetime
+
+        assert DatetimeHandler.process_value(
+            original_datetime_isoformat,
+            python_type
+        ) == original_datetime
+
+    def test_datetime_with_micro(self):
+        original_datetime = datetime_with_micro()
+        original_datetime_isoformat = original_datetime.isoformat()
+        python_type = datetime
+
+        assert DatetimeHandler.process_value(
+            original_datetime_isoformat,
+            python_type
+        ) == original_datetime
+
+    def test_datetime_simple(self):
+        original_datetime = datetime_simple()
+        original_datetime_isoformat = original_datetime.isoformat()
+        python_type = datetime
+
+        assert DatetimeHandler.process_value(
+            original_datetime_isoformat,
+            python_type
+        ) == original_datetime
+
+    def test_time_with_micro(self):
+        original_time = time_with_micro()
+        original_time_isoformat = original_time.isoformat()
+        python_type = time
+
+        assert DatetimeHandler.process_value(
+            original_time_isoformat,
+            python_type
+        ) == original_time
+
+    def test_time_simple(self):
+        original_time = time_simple()
+        original_time_isoformat = original_time.isoformat()
+        python_type = time
+
+        assert DatetimeHandler.process_value(
+            original_time_isoformat,
+            python_type
+        ) == original_time
+
+    def test_date_simple(self):
+        original_date = date_simple()
+        original_date_isoformat = original_date.isoformat()
+        python_type = date
+
+        assert DatetimeHandler.process_value(
+            original_date_isoformat,
+            python_type
+        ) == original_date

--- a/tests/types/test_timezone.py
+++ b/tests/types/test_timezone.py
@@ -63,7 +63,6 @@ def test_can_coerce_pytz_DstTzInfo():
 def test_can_coerce_pytz_StaticTzInfo():
     tzcol = TimezoneType(backend='pytz')
     tz = pytz.timezone('Pacific/Truk')
-    assert isinstance(tz, pytz.tzfile.StaticTzInfo)
     assert tzcol._coerce(tz) is tz
 
 


### PR DESCRIPTION
This commit handles datetime and time objects that contain
microseconds and timezone information better, when decrypting
values that are subclasses of datetime.datetime, datetime.time
and datetime.date. The package 'python-dateutil' is required
if a user wants to use Datetimes with the EncryptedType.

Fixes #184