### PR TITLE
Add Support for MSSQL uniqueidentifier type

### DIFF
--- a/sqlalchemy_utils/types/uuid.py
+++ b/sqlalchemy_utils/types/uuid.py
@@ -42,7 +42,7 @@ class UUIDType(types.TypeDecorator, ScalarCoercible):
 
         if dialect.name == 'mssql' and self.native:
             # Use the native UNIQUEIDENTIFIER type.
-            return dialect.type_descriptor(mssql.mssql.UNIQUEIDENTIFIER())
+            return dialect.type_descriptor(mssql.UNIQUEIDENTIFIER())
 
         else:
             # Fallback to either a BINARY or a CHAR.


### PR DESCRIPTION
This will enable utilization of MSSQL's native UUID type rather than falling back to BINARY(16) for persistence of UUIDs. 