### PR TITLE
Align code with documentation

### DIFF
--- a/sqlalchemy_utils/functions/database.py
+++ b/sqlalchemy_utils/functions/database.py
@@ -453,7 +453,7 @@ def database_exists(url):
 
     url = copy(make_url(url))
     database = url.database
-    if url.drivername.startswith('postgresql'):
+    if url.drivername.startswith('postgres'):
         url.database = 'template1'
     else:
         url.database = None
@@ -515,7 +515,7 @@ def create_database(url, encoding='utf8', template=None):
 
     database = url.database
 
-    if url.drivername.startswith('postgresql'):
+    if url.drivername.startswith('postgres'):
         url.database = 'template1'
     elif not url.drivername.startswith('sqlite'):
         url.database = None
@@ -572,7 +572,7 @@ def drop_database(url):
 
     database = url.database
 
-    if url.drivername.startswith('postgresql'):
+    if url.drivername.startswith('postgres'):
         url.database = 'template1'
     elif not url.drivername.startswith('sqlite'):
         url.database = None


### PR DESCRIPTION
When using a url scheme of `postgres` (as in the docstrings), the wrong data base will be selected (`None`), and you get the not so helpful error message `FATAL:  database "<username>" does not exist`. Using the scheme `postgresql` works as intended. As far as I understand, both schemes work for sqlalchemy in general.