### PR TITLE
Fix use of template0 and template1 with postgres.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,4 +7,4 @@ prune docs/_build
 exclude docs/_themes/.git
 include tox.ini
 include *.rst
-exclude .git
+recursive-exclude .git/*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,6 @@ recursive-include docs *
 recursive-exclude docs *.pyc
 prune docs/_build
 exclude docs/_themes/.git
+include tox.ini
+include *.rst
+exclude .git

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,3 @@ recursive-include docs *
 recursive-exclude docs *.pyc
 prune docs/_build
 exclude docs/_themes/.git
-include tox.ini
-include *.rst
-exclude .git

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,4 +7,4 @@ prune docs/_build
 exclude docs/_themes/.git
 include tox.ini
 include *.rst
-recursive-exclude .git/*
+exclude .git

--- a/sqlalchemy_utils/functions/database.py
+++ b/sqlalchemy_utils/functions/database.py
@@ -454,7 +454,7 @@ def database_exists(url):
     url = copy(make_url(url))
     database = url.database
     if url.drivername.startswith('postgres'):
-        url.database = 'template1'
+        url.database = 'postgres'
     else:
         url.database = None
 
@@ -516,7 +516,7 @@ def create_database(url, encoding='utf8', template=None):
     database = url.database
 
     if url.drivername.startswith('postgres'):
-        url.database = 'template1'
+        url.database = 'postgres'
     elif not url.drivername.startswith('sqlite'):
         url.database = None
 
@@ -530,7 +530,7 @@ def create_database(url, encoding='utf8', template=None):
             )
 
         if not template:
-            template = 'template0'
+            template = 'template1'
 
         text = "CREATE DATABASE {0} ENCODING '{1}' TEMPLATE {2}".format(
             quote(engine, database),
@@ -573,7 +573,7 @@ def drop_database(url):
     database = url.database
 
     if url.drivername.startswith('postgres'):
-        url.database = 'template1'
+        url.database = 'postgres'
     elif not url.drivername.startswith('sqlite'):
         url.database = None
 


### PR DESCRIPTION
template1 is the default template for creating a database with Postgres.
Also, tasks should connect to 'postgres' when issuing commands like CREATE DATABASE, not template1.