### PR TITLE
Update aggregate columns when subclass objects are added to the relationship

### DIFF
--- a/sqlalchemy_utils/aggregates.py
+++ b/sqlalchemy_utils/aggregates.py
@@ -534,9 +534,9 @@ class AggregationManager(object):
     def construct_aggregate_queries(self, session, ctx):
         object_dict = defaultdict(list)
         for obj in session:
-            class_ = obj.__class__
-            if class_ in self.generator_registry:
-                object_dict[class_].append(obj)
+            for class_ in self.generator_registry:
+                if isinstance(obj, class_):
+                    object_dict[class_].append(obj)
 
         for class_, objects in object_dict.items():
             for aggregate_value in self.generator_registry[class_]:

--- a/tests/aggregate/test_join_table_inheritance.py
+++ b/tests/aggregate/test_join_table_inheritance.py
@@ -13,7 +13,7 @@ def Product(Base):
         id = sa.Column(sa.Integer, primary_key=True)
         name = sa.Column(sa.Unicode(255))
         price = sa.Column(sa.Numeric)
-        type = sa.Column(sa.Unicode(255))
+        type = sa.Column(sa.String(255))
 
         __mapper_args__ = {
             'polymorphic_on': type,

--- a/tests/aggregate/test_join_table_inheritance.py
+++ b/tests/aggregate/test_join_table_inheritance.py
@@ -90,7 +90,7 @@ def CarCatalog(Catalog):
 
 
 @pytest.fixture
-def init_models(Product, Catalog, CostumeCatalog, CarCatalog):
+def init_models(AnyProduct, Catalog, CostumeCatalog, CarCatalog):
     pass
 
 


### PR DESCRIPTION
Currently, `generator_registry` only looks for absolute class matches in the `session`. This would however skip over child classes of the relationship class.

Changed the behavior to use `isinstance` checks instead.