### PR TITLE
updates existing translations

### DIFF
--- a/sqlalchemy_utils/i18n.py
+++ b/sqlalchemy_utils/i18n.py
@@ -93,6 +93,7 @@ class TranslationHybrid(object):
                 setattr(obj, attr.key, {})
             locale = cast_locale(obj, self.current_locale)
             getattr(obj, attr.key)[locale] = value
+            flag_modified(obj, attr.key)
         return setter
 
     def expr_factory(self, attr):

--- a/sqlalchemy_utils/i18n.py
+++ b/sqlalchemy_utils/i18n.py
@@ -3,6 +3,8 @@ import sqlalchemy as sa
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.sql.expression import ColumnElement
+from sqlalchemy.orm.attributes import flag_modified
+
 
 from .exceptions import ImproperlyConfigured
 

--- a/sqlalchemy_utils/i18n.py
+++ b/sqlalchemy_utils/i18n.py
@@ -5,7 +5,6 @@ from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.sql.expression import ColumnElement
 from sqlalchemy.orm.attributes import flag_modified
 
-
 from .exceptions import ImproperlyConfigured
 
 try:

--- a/sqlalchemy_utils/i18n.py
+++ b/sqlalchemy_utils/i18n.py
@@ -2,8 +2,8 @@ import six
 import sqlalchemy as sa
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.sql.expression import ColumnElement
 from sqlalchemy.orm.attributes import flag_modified
+from sqlalchemy.sql.expression import ColumnElement
 
 from .exceptions import ImproperlyConfigured
 


### PR DESCRIPTION
The content of the translation was not updated in the DB. Somehow SQLA was not aware of the changes made, no UPDATE statement was issued after `session.commit()`. 