### PR TITLE
Close connections on exists, create and drop database

### DIFF
--- a/sqlalchemy_utils/functions/database.py
+++ b/sqlalchemy_utils/functions/database.py
@@ -451,6 +451,13 @@ def database_exists(url):
 
     """
 
+    def get_result_scalar(engine, sql):
+        conn_resource = engine.execute(sql)
+        result = bool(conn_resource.scalar())
+        conn_resource.close()
+        engine.dispose()
+        return result
+
     url = copy(make_url(url))
     database = url.database
     if url.drivername.startswith('postgres'):
@@ -462,12 +469,12 @@ def database_exists(url):
 
     if engine.dialect.name == 'postgresql':
         text = "SELECT 1 FROM pg_database WHERE datname='%s'" % database
-        return bool(engine.execute(text).scalar())
+        return get_result_scalar(engine, text)
 
     elif engine.dialect.name == 'mysql':
         text = ("SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA "
                 "WHERE SCHEMA_NAME = '%s'" % database)
-        return bool(engine.execute(text).scalar())
+        return get_result_scalar(engine, text)
 
     elif engine.dialect.name == 'sqlite':
         if database:
@@ -478,15 +485,21 @@ def database_exists(url):
             return True
 
     else:
+        engine.dispose()
+        engine = None
         text = 'SELECT 1'
         try:
             url.database = database
             engine = sa.create_engine(url)
-            engine.execute(text)
+            result = engine.execute(text)
+            result.close()
             return True
 
         except (ProgrammingError, OperationalError):
             return False
+        finally:
+            if engine is not None:
+                engine.dispose()
 
 
 def create_database(url, encoding='utf8', template=None):
@@ -521,6 +534,7 @@ def create_database(url, encoding='utf8', template=None):
         url.database = None
 
     engine = sa.create_engine(url)
+    conn_resource = None
 
     if engine.dialect.name == 'postgresql':
         if engine.driver == 'psycopg2':
@@ -537,14 +551,14 @@ def create_database(url, encoding='utf8', template=None):
             encoding,
             quote(engine, template)
         )
-        engine.execute(text)
+        conn_resource = engine.execute(text)
 
     elif engine.dialect.name == 'mysql':
         text = "CREATE DATABASE {0} CHARACTER SET = '{1}'".format(
             quote(engine, database),
             encoding
         )
-        engine.execute(text)
+        conn_resource = engine.execute(text)
 
     elif engine.dialect.name == 'sqlite' and database != ':memory:':
         if database:
@@ -552,7 +566,11 @@ def create_database(url, encoding='utf8', template=None):
 
     else:
         text = 'CREATE DATABASE {0}'.format(quote(engine, database))
-        engine.execute(text)
+        conn_resource = engine.execute(text)
+
+    if conn_resource is not None:
+        conn_resource.close()
+    engine.dispose()
 
 
 def drop_database(url):
@@ -578,6 +596,7 @@ def drop_database(url):
         url.database = None
 
     engine = sa.create_engine(url)
+    conn_resource = None
 
     if engine.dialect.name == 'sqlite' and database != ':memory:':
         if database:
@@ -605,6 +624,11 @@ def drop_database(url):
         # Drop the database.
         text = 'DROP DATABASE {0}'.format(quote(connection, database))
         connection.execute(text)
+        conn_resource = connection
     else:
         text = 'DROP DATABASE {0}'.format(quote(engine, database))
-        engine.execute(text)
+        conn_resource = engine.execute(text)
+
+    if conn_resource is not None:
+        conn_resource.close()
+    engine.dispose()

--- a/sqlalchemy_utils/functions/mock.py
+++ b/sqlalchemy_utils/functions/mock.py
@@ -82,7 +82,7 @@ def mock_engine(engine, stream=None):
             target = frame.f_locals['__target']
             break
 
-        except:
+        except Exception:
             pass
 
     else:

--- a/sqlalchemy_utils/functions/render.py
+++ b/sqlalchemy_utils/functions/render.py
@@ -37,7 +37,7 @@ def render_expression(expression, bind, stream=None):
             local['engine'] = engine
             six.exec_(expression, frame.f_globals, local)
             break
-        except:
+        except Exception:
             pass
     else:
         raise ValueError('Not a valid python expression', engine)

--- a/sqlalchemy_utils/types/arrow.py
+++ b/sqlalchemy_utils/types/arrow.py
@@ -12,7 +12,7 @@ from .scalar_coercible import ScalarCoercible
 arrow = None
 try:
     import arrow
-except:
+except ImportError:
     pass
 
 

--- a/tests/functions/test_database.py
+++ b/tests/functions/test_database.py
@@ -99,3 +99,22 @@ class TestDatabasePostgresWithQuotedName(DatabaseTest):
             postgresql_db_user
         )
         create_database(dsn, template='my-template')
+
+
+class TestDatabasePostgresCreateDatabaseCloseConnection(object):
+    def test_create_database_twice(self, postgresql_db_user):
+        dsn_list = [
+            'postgres://{0}@localhost/db_test_sqlalchemy-util-a'.format(
+                postgresql_db_user
+            ),
+            'postgres://{0}@localhost/db_test_sqlalchemy-util-b'.format(
+                postgresql_db_user
+            ),
+        ]
+        for dsn_item in dsn_list:
+            assert not database_exists(dsn_item)
+            create_database(dsn_item, template="template1")
+            assert database_exists(dsn_item)
+        for dsn_item in dsn_list:
+            drop_database(dsn_item)
+            assert not database_exists(dsn_item)

--- a/tests/types/test_phonenumber.py
+++ b/tests/types/test_phonenumber.py
@@ -79,7 +79,7 @@ class TestPhoneNumber(object):
             try:
                 number = PhoneNumber(raw_number, 'FI')
                 assert not number.is_valid_number()
-            except:
+            except Exception:
                 pass
 
     def test_invalid_phone_numbers_throw_dont_wrap_exception(
@@ -96,7 +96,7 @@ class TestPhoneNumber(object):
             )
         except PhoneNumberParseException:
             pass
-        except:
+        except Exception:
             assert False
 
     def test_phone_number_attributes(self):


### PR DESCRIPTION
The functions `database_exists`, `create_database` and `drop_database` all creates its own engines, however after using its connections it leaved them to the garbage collector.

This created some problems in some circumstances (e.g. calling twice `create_database` with different database names) because the connections were open when the second call is executed before the engine is garbage collected, see #288.

This try to fix it and add a regression test for PostgreSQL (unfortunately I don't know how to raise the error in MySQL or SQLite).

As a side change, fix the flake8 error E722, which was recently enabled by default in the latest flake8 versions.