### PR TITLE
Add optional JSON Schema and custom validator to JSONType

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,8 @@ extras_require = {
     'enum': ['enum34'] if sys.version_info < (3, 4) else [],
     'timezone': ['python-dateutil'],
     'url': ['furl >= 0.4.1'],
-    'encrypted': ['cryptography>=0.6']
+    'encrypted': ['cryptography>=0.6'],
+    'jsonschema': ['jsonschema>=2.6.0'],
 }
 
 

--- a/sqlalchemy_utils/types/json.py
+++ b/sqlalchemy_utils/types/json.py
@@ -61,8 +61,8 @@ class JSONType(sa.types.TypeDecorator):
         session.commit()
 
 
-    If you have jsonschema_ installed, you may provide a schema :class:`dict` to the
-    `schema` keyword and enjoy validation on commit.
+    If you have jsonschema_ installed, you may provide a schema :class:`dict`
+    to the `schema` keyword and enjoy validation on commit.
 
     ::
 

--- a/sqlalchemy_utils/types/json.py
+++ b/sqlalchemy_utils/types/json.py
@@ -12,6 +12,12 @@ try:
 except ImportError:
     import json as json
 
+jsonschema = None
+try:
+    import jsonschema
+except ImportError:
+    pass
+
 try:
     from sqlalchemy.dialects.postgresql import JSON
     has_postgres_json = True
@@ -31,7 +37,7 @@ class JSONType(sa.types.TypeDecorator):
     """
     JSONType offers way of saving JSON data structures to database. On
     PostgreSQL the underlying implementation of this data type is 'json' while
-    on other databases its simply 'text'.
+    on other databases it's simply 'text'.
 
     ::
 
@@ -53,14 +59,75 @@ class JSONType(sa.types.TypeDecorator):
             'max-speed': '400 mph'
         }
         session.commit()
+
+
+    If you have jsonschema_ installed, you may provide a schema :class:`dict` to the
+    `schema` keyword and enjoy validation on commit.
+
+    ::
+
+
+        from sqlalchemy_utils import JSONType
+
+
+        class Product(Base):
+            __tablename__ = 'product'
+            id = sa.Column(sa.Integer, autoincrement=True)
+            name = sa.Column(sa.Unicode(50))
+            details = sa.Column(JSONType(schema={
+                'type': 'object',
+                'required': ['type'],
+                'properties': {
+                    'color': {'type': 'string'},
+                    'max-speed': {'type': 'number'},
+                    'type': {'type': 'string'},
+                }
+            }))
+
+
+        product = Product()
+        product.details = {
+            'color': 'red',
+            'type': 'car',
+            'max-speed': '400 mph'
+        }
+        session.commit()
+        # raises a sqlalchemy.exc.StatementError
+
+
+    If not provided, the `validator` will be inferred from your schema,
+    and a single instance stored for reuse through the life of your model
+    class.
+
+    If you need fine-grained control over how your validation works,
+    specify an instance of an implementation of
+    :class:`jsonschema.validators.IValidator`.
+
+    .. _jsonschema: https://github.com/Julian/jsonschema
     """
     impl = sa.UnicodeText
+    schema = None
+    validator = None
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, schema=None, validator=None,
+                 *args, **kwargs):
         if json is None:
             raise ImproperlyConfigured(
                 'JSONType needs anyjson package installed.'
             )
+        if schema is not None:
+            if jsonschema is None:
+                raise ImproperlyConfigured(
+                    'JSONType needs the `jsonschema` package installed for'
+                    ' JSON Schema validation'
+                )
+            self.schema = schema
+            if validator is not None:
+                self.validator = validator
+            else:
+                validator_cls = jsonschema.validators.validator_for(schema)
+                validator_cls.check_schema(schema)
+                self.validator = validator_cls(schema)
         super(JSONType, self).__init__(*args, **kwargs)
 
     def load_dialect_impl(self, dialect):
@@ -74,6 +141,8 @@ class JSONType(sa.types.TypeDecorator):
             return dialect.type_descriptor(self.impl)
 
     def process_bind_param(self, value, dialect):
+        if self.validator is not None:
+            self.validator.validate(value, self.schema)
         if dialect.name == 'postgresql' and has_postgres_json:
             return value
         if value is not None:

--- a/tests/types/test_json_schema.py
+++ b/tests/types/test_json_schema.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+import pytest
+import sqlalchemy as sa
+
+from sqlalchemy_utils.types import json
+
+try:
+    import jsonschema
+except ImportError:
+    jsonschema = None
+
+
+@pytest.fixture
+def schema():
+    return {
+        'oneOf': [
+            {'type': 'array', 'items': {'type': 'number'}},
+            {'type': 'object', 'properties': {'something': {'oneOf': [
+                {'type': 'number'},
+                {'type': 'string'},
+            ]}}},
+        ]
+    }
+
+
+@pytest.fixture
+def Document(Base, schema):
+    class Document(Base):
+        __tablename__ = 'document'
+        id = sa.Column(sa.Integer, primary_key=True)
+        json = sa.Column(json.JSONType(schema=schema))
+    return Document
+
+
+@pytest.fixture
+def CustomValidatorDocument(Base, schema):
+    class CustomValidator(jsonschema.validators.Draft4Validator):
+        def __init__(self, *args, **kwargs):
+            self.call_count = 0
+            super(CustomValidator, self).__init__(*args, **kwargs)
+
+        def validate(self, *args, **kwargs):
+            self.call_count += 1
+            super(CustomValidator, self).validate(*args, **kwargs)
+
+    validator = CustomValidator(schema)
+
+    class CustomValidatorDocument(Base):
+        __tablename__ = 'custom_document'
+        id = sa.Column(sa.Integer, primary_key=True)
+        json = sa.Column(json.JSONType(schema=schema, validator=validator))
+        _validator = validator
+
+    return CustomValidatorDocument
+
+
+@pytest.fixture
+def init_models(Document, CustomValidatorDocument):
+    pass
+
+
+@pytest.mark.skipif('jsonschema is None')
+class JSONSchemaTestCase(object):
+
+    def test_list(self, session, Document):
+        document = Document(
+            json=[1, 2, 3]
+        )
+
+        session.add(document)
+        session.commit()
+
+        document = session.query(Document).first()
+        assert document.json == [1, 2, 3]
+
+    def test_parameter_processing(self, session, Document):
+        document = Document(
+            json={'something': 12}
+        )
+
+        session.add(document)
+        session.commit()
+
+        document = session.query(Document).first()
+        assert document.json == {'something': 12}
+
+    def test_non_ascii_chars(self, session, Document):
+        document = Document(
+            json={'something': u'äääööö'}
+        )
+
+        session.add(document)
+        session.commit()
+
+        document = session.query(Document).first()
+        assert document.json == {'something': u'äääööö'}
+
+    def test_schema_validate(self, session, Document):
+        document = Document(json='something')
+
+        session.add(document)
+
+        with pytest.raises(sa.exc.StatementError):
+            session.commit()
+
+    def test_custom_validator(self, session, CustomValidatorDocument):
+        custom_document = CustomValidatorDocument(json='something')
+        validator = CustomValidatorDocument._validator
+
+        session.add(custom_document)
+
+        assert validator.call_count == 0
+        with pytest.raises(sa.exc.StatementError):
+            session.commit()
+        assert validator.call_count == 1
+
+        session.rollback()
+
+        custom_document.json = {'something': 1}
+        session.add(custom_document)
+        session.commit()
+        assert validator.call_count == 2
+
+
+@pytest.mark.skipif('jsonschema is None')
+@pytest.mark.skipif('json.json is None')
+@pytest.mark.usefixtures('sqlite_memory_dsn')
+class TestSqliteJSONType(JSONSchemaTestCase):
+    pass
+
+
+@pytest.mark.skipif('jsonschema is None')
+@pytest.mark.skipif('json.json is None')
+@pytest.mark.usefixtures('postgresql_dsn')
+class TestPostgresJSONType(JSONSchemaTestCase):
+    pass


### PR DESCRIPTION
Hi folks! ❤️  the work!

This is a little PR for giving users the ability to validate their `JSONType`s with a [JSON Schema](http://json-schema.org/) as implemented by [jsonschema](https://github.com/Julian/jsonschema).

I initially started making it a separate type, but in my use of `JSONType`, I've basically never used it as a "random store of stuff I don't understand," but can go to that approach if desired.

An example use case: I'd like to store a Jupyter Notebook in a `JSONType`. I'd go pull the [nbformat schema](https://github.com/jupyter/nbformat/blob/master/nbformat/v4/nbformat.v4.schema.json), put it on a `notebook` column, and be able to confidently toss it into my database.

The custom `validator` stuff is a bit advanced, but is pretty important for being able to really hone in on how you want validation to work, especially if you are using existing schema that you don't control, or you want to use multi-file features.