### PR TITLE
Miscellaneous linting and test bugfixes

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,6 @@
 [settings]
 known_first_party=sqlalchemy_utils
+known_third_party=flexmock
 line_length=79
 multi_line_output=3
 not_skip=__init__.py

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -22,7 +22,7 @@ Installing an official release
 You can install the most recent official SQLAlchemy-Utils version using
 pip_::
 
-    pip install sqlalchemy-utils
+    pip install sqlalchemy-utils    # Use `pip3` instead of `pip` for Python 3.x
 
 .. _pip: http://www.pip-installer.org/
 
@@ -34,11 +34,10 @@ copy of the source. You can do that by cloning the git_ repository::
 
     git clone git://github.com/kvesteri/sqlalchemy-utils.git
 
-Then you can install the source distribution using the ``setup.py``
-script::
+Then you can install the source distribution using pip::
 
     cd sqlalchemy-utils
-    python setup.py install
+    pip install -e .    # Use `pip3` instead of `pip` for Python 3.x
 
 .. _git: http://git-scm.org/
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -13,6 +13,7 @@ SQLAlchemy-Utils has been tested against the following Python platforms.
 - cPython 3.3
 - cPython 3.4
 - cPython 3.5
+- cPython 3.6
 
 
 Installing an official release

--- a/sqlalchemy_utils/functions/mock.py
+++ b/sqlalchemy_utils/functions/mock.py
@@ -82,7 +82,7 @@ def mock_engine(engine, stream=None):
             target = frame.f_locals['__target']
             break
 
-        except:
+        except Exception:
             pass
 
     else:

--- a/sqlalchemy_utils/functions/render.py
+++ b/sqlalchemy_utils/functions/render.py
@@ -37,7 +37,7 @@ def render_expression(expression, bind, stream=None):
             local['engine'] = engine
             six.exec_(expression, frame.f_globals, local)
             break
-        except:
+        except Exception:
             pass
     else:
         raise ValueError('Not a valid python expression', engine)

--- a/sqlalchemy_utils/types/arrow.py
+++ b/sqlalchemy_utils/types/arrow.py
@@ -12,7 +12,7 @@ from .scalar_coercible import ScalarCoercible
 arrow = None
 try:
     import arrow
-except:
+except ImportError:
     pass
 
 

--- a/sqlalchemy_utils/types/phone_number.py
+++ b/sqlalchemy_utils/types/phone_number.py
@@ -123,7 +123,10 @@ class PhoneNumber(BasePhoneNumber):
         return self.national, self.region
 
     def is_valid_number(self):
-        return phonenumbers.is_valid_number(self._phone_number)
+        try:
+            return phonenumbers.is_valid_number(self._phone_number)
+        except NumberParseException:
+            return False
 
     def __unicode__(self):
         return self.national

--- a/sqlalchemy_utils/types/phone_number.py
+++ b/sqlalchemy_utils/types/phone_number.py
@@ -123,10 +123,7 @@ class PhoneNumber(BasePhoneNumber):
         return self.national, self.region
 
     def is_valid_number(self):
-        try:
-            return phonenumbers.is_valid_number(self._phone_number)
-        except NumberParseException:
-            return False
+        return phonenumbers.is_valid_number(self._phone_number)
 
     def __unicode__(self):
         return self.national

--- a/tests/types/test_phonenumber.py
+++ b/tests/types/test_phonenumber.py
@@ -76,8 +76,8 @@ class TestPhoneNumber(object):
 
     def test_invalid_phone_numbers(self, invalid_phone_numbers):
         for raw_number in invalid_phone_numbers:
-            number = PhoneNumber(raw_number, 'FI')
-            assert not number.is_valid_number()
+            with pytest.raises(PhoneNumberParseException):
+                PhoneNumber(raw_number, 'FI')
 
     def test_invalid_phone_numbers_throw_dont_wrap_exception(
         self,

--- a/tests/types/test_phonenumber.py
+++ b/tests/types/test_phonenumber.py
@@ -10,27 +10,22 @@ from sqlalchemy_utils import (  # noqa
 )
 
 
-@pytest.fixture
-def valid_phone_numbers():
-    return [
-        '040 1234567',
-        '+358 401234567',
-        '09 2501234',
-        '+358 92501234',
-        '0800 939393',
-        '09 4243 0456',
-        '0600 900 500'
-    ]
+VALID_PHONE_NUMBERS = (
+    '040 1234567',
+    '+358 401234567',
+    '09 2501234',
+    '+358 92501234',
+    '0800 939393',
+    '09 4243 0456',
+    '0600 900 500'
+)
 
 
-@pytest.fixture
-def invalid_phone_numbers():
-    return [
-        'abc',
-        '+040 1234567',
-        '0111234567',
-        '358'
-    ]
+INVALID_PHONE_NUMBERS = (
+    '+040 1234567',
+    '0111234567',
+    '358'
+)
 
 
 @pytest.fixture
@@ -69,15 +64,19 @@ def user(session, User, phone_number):
 @pytest.mark.skipif('types.phone_number.phonenumbers is None')
 class TestPhoneNumber(object):
 
-    def test_valid_phone_numbers(self, valid_phone_numbers):
-        for raw_number in valid_phone_numbers:
-            number = PhoneNumber(raw_number, 'FI')
-            assert number.is_valid_number()
+    @pytest.mark.parametrize('raw_number', VALID_PHONE_NUMBERS)
+    def test_valid_phone_numbers(self, raw_number):
+        number = PhoneNumber(raw_number, 'FI')
+        assert number.is_valid_number()
 
-    def test_invalid_phone_numbers(self, invalid_phone_numbers):
-        for raw_number in invalid_phone_numbers:
-            with pytest.raises(PhoneNumberParseException):
-                PhoneNumber(raw_number, 'FI')
+    def test_invalid_phone_number_non_numeric(self):
+        with pytest.raises(PhoneNumberParseException):
+            PhoneNumber('abc', 'FI')
+
+    @pytest.mark.parametrize('raw_number', INVALID_PHONE_NUMBERS)
+    def test_invalid_phone_numbers(self, raw_number):
+        number = PhoneNumber(raw_number, 'FI')
+        assert not number.is_valid_number()
 
     def test_invalid_phone_numbers_throw_dont_wrap_exception(
         self,

--- a/tests/types/test_phonenumber.py
+++ b/tests/types/test_phonenumber.py
@@ -9,7 +9,6 @@ from sqlalchemy_utils import (  # noqa
     types
 )
 
-
 VALID_PHONE_NUMBERS = (
     '040 1234567',
     '+358 401234567',

--- a/tests/types/test_phonenumber.py
+++ b/tests/types/test_phonenumber.py
@@ -21,13 +21,6 @@ VALID_PHONE_NUMBERS = (
 )
 
 
-INVALID_PHONE_NUMBERS = (
-    '+040 1234567',
-    '0111234567',
-    '358'
-)
-
-
 @pytest.fixture
 def User(Base):
     class User(Base):
@@ -69,12 +62,13 @@ class TestPhoneNumber(object):
         number = PhoneNumber(raw_number, 'FI')
         assert number.is_valid_number()
 
-    def test_invalid_phone_number_non_numeric(self):
+    @pytest.mark.parametrize('raw_number', ('abc', '+040 1234567'))
+    def test_invalid_phone_numbers__constructor_fails(self, raw_number):
         with pytest.raises(PhoneNumberParseException):
-            PhoneNumber('abc', 'FI')
+            PhoneNumber(raw_number, 'FI')
 
-    @pytest.mark.parametrize('raw_number', INVALID_PHONE_NUMBERS)
-    def test_invalid_phone_numbers(self, raw_number):
+    @pytest.mark.parametrize('raw_number', ('0111234567', '358'))
+    def test_invalid_phone_numbers__is_valid_number(self, raw_number):
         number = PhoneNumber(raw_number, 'FI')
         assert not number.is_valid_number()
 

--- a/tests/types/test_phonenumber.py
+++ b/tests/types/test_phonenumber.py
@@ -76,28 +76,21 @@ class TestPhoneNumber(object):
 
     def test_invalid_phone_numbers(self, invalid_phone_numbers):
         for raw_number in invalid_phone_numbers:
-            try:
-                number = PhoneNumber(raw_number, 'FI')
-                assert not number.is_valid_number()
-            except:
-                pass
+            number = PhoneNumber(raw_number, 'FI')
+            assert not number.is_valid_number()
 
     def test_invalid_phone_numbers_throw_dont_wrap_exception(
         self,
         session,
         User
     ):
-        try:
+        with pytest.raises(PhoneNumberParseException):
             session.execute(
                 User.__table__.insert().values(
                     name=u'Someone',
                     phone_number=u'abc'
                 )
             )
-        except PhoneNumberParseException:
-            pass
-        except:
-            assert False
 
     def test_phone_number_attributes(self):
         number = PhoneNumber('+358401234567')

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, py34, py35, py36, lint
+envlist = py27, py33, py34, py35, py36, lint
 
 [testenv]
 commands =
@@ -7,9 +7,6 @@ commands =
 deps =
     .[test_all]
 passenv = SQLALCHEMY_UTILS_TEST_DB SQLALCHEMY_UTILS_TEST_POSTGRESQL_USER SQLALCHEMY_UTILS_TEST_MYSQL_USER
-
-[testenv:py26]
-recreate = True
 
 [testenv:py27]
 recreate = True


### PR DESCRIPTION
Master is broken and some of the tests mask errors, passing even if the tested code fails. This PR does the following:

* Fixed various bare `except` statements that the linter complained about.
* `test_invalid_phone_numbers` would always pass because of the bare try-except, even if the code it tests was broken.
* `test_invalid_phone_numbers_throw_dont_wrap_exception` would hide any exception thrown and fail with an `assert False` error, which is really hard to debug.
* Removed Python 2.6 from `tox`
* Added mention of support for Python 3.6 in the documentation.
* Altered installation instructions to include Python 3 steps as well.
* Add `flexmock` as a known third party library so `isort` doesn't complain about its placement