### PR TITLE
Improve compatibility for migration tools.

### DIFF
--- a/sqlalchemy_utils/types/uuid.py
+++ b/sqlalchemy_utils/types/uuid.py
@@ -28,7 +28,7 @@ class UUIDType(types.TypeDecorator, ScalarCoercible):
 
     python_type = uuid.UUID
 
-    def __init__(self, binary=True, native=True):
+    def __init__(self, binary=True, native=True, **kwargs):
         """
         :param binary: Whether to use a BINARY(16) or CHAR(32) fallback.
         """


### PR DESCRIPTION
thanks SQLAlchemy-Utils save my time.

there is some problem when work with flask-migrate. (may caused by alembic)

error like this:
```
File "... .../migrations/versions/c7bead11a48b_.py", line 39, in upgrade
    sa.Column('code', sqlalchemy_utils.types.uuid.UUIDType(length=16), nullable=False),
TypeError: __init__() got an unexpected keyword argument 'length'
```

that because UUIDType doesn't allow this argument. 
So I add `**kwargs` to improve  compatibility  
