### PR TITLE
Add Ltree.descendant_of and Ltree.ancestor_of

### DIFF
--- a/sqlalchemy_utils/primitives/ltree.py
+++ b/sqlalchemy_utils/primitives/ltree.py
@@ -128,6 +128,28 @@ class Ltree(object):
                 return index
         raise ValueError('subpath not found')
 
+    def descendant_of(self, other):
+        """
+        is left argument a descendant of right (or equal)?
+
+        ::
+
+            assert Ltree('1.2.3.4.5').descendant_of('1.2.3')
+        """
+        subpath = self[:len(Ltree(other))]
+        return subpath == other
+
+    def ancestor_of(self, other):
+        """
+        is left argument an ancestor of right (or equal)?
+
+        ::
+
+            assert Ltree('1.2.3').ancestor_of('1.2.3.4.5')
+        """
+        subpath = Ltree(other)[:len(self)]
+        return subpath == self
+
     def __getitem__(self, key):
         if isinstance(key, int):
             return Ltree(self.path.split('.')[key])

--- a/tests/primitives/test_ltree.py
+++ b/tests/primitives/test_ltree.py
@@ -141,6 +141,37 @@ class TestLtree(object):
     def test_contains(self, path, other, result):
         assert (other in Ltree(path)) == result
 
+    @pytest.mark.parametrize(
+        ('path', 'other', 'result'),
+        (
+            ('1', '1.2.3', True),
+            ('1.2', '1.2.3', True),
+            ('1.2.3', '1.2.3', True),
+            ('1.2.3', '1', False),
+            ('1.2.3', '1.2', False),
+            ('1', '1', True),
+            ('1', '2', False),
+        )
+    )
+    def test_ancestor_of(self, path, other, result):
+        assert Ltree(path).ancestor_of(other) == result
+
+    @pytest.mark.parametrize(
+        ('path', 'other', 'result'),
+        (
+            ('1', '1.2.3', False),
+            ('1.2', '1.2.3', False),
+            ('1.2', '1.2.3', False),
+            ('1.2.3', '1', True),
+            ('1.2.3', '1.2', True),
+            ('1.2.3', '1.2.3', True),
+            ('1', '1', True),
+            ('1', '2', False),
+        )
+    )
+    def test_descendant_of(self, path, other, result):
+        assert Ltree(path).descendant_of(other) == result
+
     def test_getitem_with_other_than_slice_or_in(self):
         with pytest.raises(TypeError):
             Ltree('1.2')['something']


### PR DESCRIPTION
Matches behavior of equivalent LtreeType methods

Also add tests, using slice comparison

This allows for easier comparisons after query time, instead of needing to do
``model.ltreecol.path.startswith(other.ltreecol.path)`` or the like