### PR TITLE
Fix emition of DDL statements.

### DIFF
--- a/sqlalchemy_utils/types/ltree.py
+++ b/sqlalchemy_utils/types/ltree.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from sqlalchemy import types
-from sqlalchemy.dialects.postgresql import ARRAY
+from sqlalchemy.dialects.postgresql import ARRAY, dialect
 from sqlalchemy.dialects.postgresql.base import ischema_names, PGTypeCompiler
 from sqlalchemy.sql import expression
 
@@ -85,6 +85,9 @@ class LtreeType(types.Concatenable, types.UserDefinedType, ScalarCoercible):
         if value:
             return Ltree(value)
 
+    def _default_dialect(self, default=None):
+        return dialect()
+
 
 class LQUERY(types.TypeEngine):
     """Postresql LQUERY type.
@@ -92,12 +95,18 @@ class LQUERY(types.TypeEngine):
     """
     __visit_name__ = 'LQUERY'
 
+    def _default_dialect(self, default=None):
+        return dialect()
+
 
 class LTXTQUERY(types.TypeEngine):
     """Postresql LTXTQUERY type.
     See :class:`LTREE` for details.
     """
     __visit_name__ = 'LTXTQUERY'
+
+    def _default_dialect(self, default=None):
+        return dialect()
 
 
 ischema_names['ltree'] = LtreeType


### PR DESCRIPTION
Type `Ltree` and similar are broken since it does not emits DDL at all on `GenericTypeCompiler`. It means that packages like `sadisplay` are not able to use ORM and to get type of columns. So, in this pull request I force `Ltree` to use `PGTypeCompiler` for expression compiling.