### PR TITLE
Add module loads

### DIFF
--- a/sqlalchemy_utils/types/encrypted/__init__.py
+++ b/sqlalchemy_utils/types/encrypted/__init__.py
@@ -1,1 +1,3 @@
 # Module for encrypted type
+from .encrypted_type import *
+from .padding import *


### PR DESCRIPTION
This is currently throwing errors using superset, a module that has sqlalchemy_utils as a dependency-

  File "/home/user/anaconda3/lib/python3.6/site-packages/superset/migrations/versions/289ce07647b_add_encrypted_password_field.py", line 15, in <module>
    from sqlalchemy_utils.types.encrypted import EncryptedType
ImportError: cannot import name 'EncryptedType'