### PR TITLE
Simplify providing custom JSON encoder

### DIFF
--- a/sqlalchemy_utils/types/json.py
+++ b/sqlalchemy_utils/types/json.py
@@ -55,9 +55,10 @@ class JSONType(sa.types.TypeDecorator):
         session.commit()
     """
     impl = sa.UnicodeText
+    json = json
 
     def __init__(self, *args, **kwargs):
-        if json is None:
+        if self.json is None:
             raise ImproperlyConfigured(
                 'JSONType needs anyjson package installed.'
             )
@@ -77,12 +78,12 @@ class JSONType(sa.types.TypeDecorator):
         if dialect.name == 'postgresql' and has_postgres_json:
             return value
         if value is not None:
-            value = six.text_type(json.dumps(value))
+            value = six.text_type(self.json.dumps(value))
         return value
 
     def process_result_value(self, value, dialect):
         if dialect.name == 'postgresql':
             return value
         if value is not None:
-            value = json.loads(value)
+            value = self.json.loads(value)
         return value


### PR DESCRIPTION
This a POC for allowing to provide a custom JSON encoder to the type. Let me know what you think and I'll polish the PR.

Right now it's possible to monkey patch `json`, but it's not very clean (nor officially supported):

```python
import json as json_module
from decimal import Decimal
from datetime import datetime

from flask.json import JSONEncoder as FlaskJSONEncoder
from sqlalchemy_utils.types import json as sqlalchemy_utils


class JSONEncoder(FlaskJSONEncoder):
    def default(self, obj):
        if isinstance(obj, Decimal):
            return str(obj)
        if isinstance(obj, datetime):
            return obj.isoformat()
        return FlaskJSONEncoder.default(self, obj)


class MyJSON:
    def dumps(self, *args, **kwargs):  # pragma: no cover
        return json_module.dumps(*args, **kwargs, cls=JSONEncoder)

    def loads(self, *args, **kwargs):  # pragma: no cover
        return json_module.loads(*args, **kwargs)


json = MyJSON()

# Monkey patch JSON encoder
sqlalchemy_utils.json = json
```