### PR TITLE
#347 support of short-code in phone number type

### DIFF
--- a/sqlalchemy_utils/types/phone_number.py
+++ b/sqlalchemy_utils/types/phone_number.py
@@ -29,7 +29,7 @@ class PhoneNumberParseException(NumberParseException, exc.DontWrapMixin):
 
 @str_coercible
 class PhoneNumber(BasePhoneNumber):
-    '''
+    """
     Extends a PhoneNumber class from `Python phonenumbers library`_. Adds
     different phone number formats to attributes, so they can be easily used
     in templates. Phone number validation method is also implemented.
@@ -72,8 +72,12 @@ class PhoneNumber(BasePhoneNumber):
         String representation of the phone number.
     :param region:
         Region of the phone number.
-    '''
-    def __init__(self, raw_number, region=None):
+    :param check_region:
+        Whether to check the supplied region parameter;
+        should always be True for external callers.
+        Can be useful for short codes or toll free
+    """
+    def __init__(self, raw_number, region=None, check_region=True):
         # Bail if phonenumbers is not found.
         if phonenumbers is None:
             raise ImproperlyConfigured(
@@ -81,7 +85,11 @@ class PhoneNumber(BasePhoneNumber):
             )
 
         try:
-            self._phone_number = phonenumbers.parse(raw_number, region)
+            self._phone_number = phonenumbers.parse(
+                raw_number,
+                region,
+                _check_region=check_region
+            )
         except NumberParseException as e:
             # Wrap exception so SQLAlchemy doesn't swallow it as a
             # StatementError

--- a/sqlalchemy_utils/types/scalar_coercible.py
+++ b/sqlalchemy_utils/types/scalar_coercible.py
@@ -1,6 +1,6 @@
 class ScalarCoercible(object):
     def _coerce(self, value):
-        raise NotImplemented
+        raise NotImplementedError
 
     def coercion_listener(self, target, value, oldvalue, initiator):
         return self._coerce(value)

--- a/tests/types/test_phonenumber.py
+++ b/tests/types/test_phonenumber.py
@@ -90,6 +90,18 @@ class TestPhoneNumber(object):
         assert number.international == u'+358 40 1234567'
         assert number.national == u'040 1234567'
 
+    def test_phone_number_attributes_for_short_code(self):
+        """
+        For international and national shortcode remains the same, if we pass
+        short code to PhoneNumber library without giving check_region it will
+        raise exception
+        :return:
+        """
+        number = PhoneNumber('72404', check_region=False)
+        assert number.e164 == u'+072404'
+        assert number.international == u'72404'
+        assert number.national == u'72404'
+
     def test_phone_number_str_repr(self):
         number = PhoneNumber('+358401234567')
         if six.PY2:


### PR DESCRIPTION
Use of _check_region parameter of phonenumbers library. If this parameter's value is false then it will not check for the region it simple bypasses the region