### PR TITLE
Check for SQLite header in `database_exists`

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -73,7 +73,7 @@ def sqlite_none_database_dsn():
 
 
 @pytest.fixture
-def sqlite_file_dsn():
+def sqlite_file_dsn(db_name):
     return 'sqlite:///{0}.db'.format(db_name)
 
 

--- a/tests/functions/test_database.py
+++ b/tests/functions/test_database.py
@@ -35,7 +35,10 @@ class TestDatabaseSQLiteMemoryNoDatabaseString(object):
 
 @pytest.mark.usefixtures('sqlite_file_dsn')
 class TestDatabaseSQLiteFile(DatabaseTest):
-    pass
+    def test_existing_non_sqlite_file(self, dsn):
+        database = sa.engine.url.make_url(dsn).database
+        open(database, 'w').close()
+        self.test_create_and_drop(dsn)
 
 
 @pytest.mark.skipif('pymysql is None')


### PR DESCRIPTION
Along with this change, `create_database` will also create an actual
SQLite database file instead of just an empty file.

Fixes #306 