### PR TITLE
Remove deprecated ``sudo: false`` from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: python
 
 addons:


### PR DESCRIPTION
See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration