### PR TITLE
Fix #303: Support creating and dropping a PostgreSQL database when using pg8000 driver

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ extras_require = {
         'flexmock>=0.9.7',
         'mock==2.0.0',
         'psycopg2>=2.5.1',
+        'pg8000>=1.12.4',
         'pytz>=2014.2',
         'python-dateutil>=2.2',
         'pymysql',

--- a/sqlalchemy_utils/__init__.py
+++ b/sqlalchemy_utils/__init__.py
@@ -100,4 +100,4 @@ from .view import (  # noqa
     refresh_materialized_view
 )
 
-__version__ = '0.33.10'
+__version__ = '0.33.11.dev1'

--- a/sqlalchemy_utils/functions/database.py
+++ b/sqlalchemy_utils/functions/database.py
@@ -546,6 +546,8 @@ def create_database(url, encoding='utf8', template=None):
 
     if url.drivername == 'mssql+pyodbc':
         engine = sa.create_engine(url, connect_args={'autocommit': True})
+    elif url.drivername == 'postgresql+pg8000':
+        engine = sa.create_engine(url, isolation_level='AUTOCOMMIT')
     else:
         engine = sa.create_engine(url)
     result_proxy = None

--- a/sqlalchemy_utils/functions/database.py
+++ b/sqlalchemy_utils/functions/database.py
@@ -616,6 +616,8 @@ def drop_database(url):
 
     if url.drivername == 'mssql+pyodbc':
         engine = sa.create_engine(url, connect_args={'autocommit': True})
+    elif url.drivername == 'postgresql+pg8000':
+        engine = sa.create_engine(url, isolation_level='AUTOCOMMIT')
     else:
         engine = sa.create_engine(url)
     conn_resource = None

--- a/tests/functions/test_database.py
+++ b/tests/functions/test_database.py
@@ -104,6 +104,18 @@ class TestDatabasePostgresWithQuotedName(DatabaseTest):
         create_database(dsn, template='my-template')
 
 
+class TestDatabasePostgresPg8000(object):
+
+    def test_create_database_pg8000_driver(self, postgresql_db_user, db_name):
+        dsn = 'postgresql+pg8000://{0}@localhost/{1}'.format(
+            postgresql_db_user,
+            db_name
+        )
+        assert not database_exists(dsn)
+        create_database(dsn)
+        assert database_exists(dsn)
+
+
 class TestDatabasePostgresCreateDatabaseCloseConnection(object):
     def test_create_database_twice(self, postgresql_db_user):
         dsn_list = [

--- a/tests/functions/test_database.py
+++ b/tests/functions/test_database.py
@@ -81,6 +81,16 @@ class TestDatabasePostgres(DatabaseTest):
         create_database(dsn, template='my_template')
 
 
+class TestDatabasePostgresPg8000(DatabaseTest):
+
+    @pytest.fixture
+    def dsn(self, postgresql_db_user):
+        return 'postgresql+pg8000://{0}@localhost/{1}'.format(
+            postgresql_db_user,
+            'db_to_test_create_and_drop_via_pg8000_driver'
+        )
+
+
 @pytest.mark.usefixtures('postgresql_dsn')
 class TestDatabasePostgresWithQuotedName(DatabaseTest):
 
@@ -102,18 +112,6 @@ class TestDatabasePostgresWithQuotedName(DatabaseTest):
             postgresql_db_user
         )
         create_database(dsn, template='my-template')
-
-
-class TestDatabasePostgresPg8000(object):
-
-    def test_create_database_pg8000_driver(self, postgresql_db_user, db_name):
-        dsn = 'postgresql+pg8000://{0}@localhost/{1}'.format(
-            postgresql_db_user,
-            '{}_to_test_pg8000_driver'.format(db_name)
-        )
-        assert not database_exists(dsn)
-        create_database(dsn)
-        assert database_exists(dsn)
 
 
 class TestDatabasePostgresCreateDatabaseCloseConnection(object):

--- a/tests/functions/test_database.py
+++ b/tests/functions/test_database.py
@@ -109,7 +109,7 @@ class TestDatabasePostgresPg8000(object):
     def test_create_database_pg8000_driver(self, postgresql_db_user, db_name):
         dsn = 'postgresql+pg8000://{0}@localhost/{1}'.format(
             postgresql_db_user,
-            db_name
+            '{}_to_test_pg8000_driver'.format(db_name)
         )
         assert not database_exists(dsn)
         create_database(dsn)


### PR DESCRIPTION
As reported by #303 current implementation of create_database/drop_database doesn't support creating/dropping a PostgreSQL database when connecting using [pg8000 driver](https://docs.sqlalchemy.org/en/latest/dialects/postgresql.html#module-sqlalchemy.dialects.postgresql.pg8000). The reason is when pg8000 driver is used (i.e. when the drivername is `postgresql+pg8000`), create_database/drop_database doesn't set the isolation level needed to execute the 'create database'/'drop database' command on PostgreSQL. This PR is fixing that.
- Commits  5dec6f23883bc411a4e9136db781a6de1e442239 and ebd6b10b8aee827e1f84202e397d2f3a365b0a77 add a TC that tests creating a PostgreSQL DB using pg8000. Only the TC without the fix was added first so the travis-ci job fails to reproduce the error ([see the TC failure here](https://travis-ci.org/kvesteri/sqlalchemy-utils/jobs/478001813#L3506)).
- The following commit adds support to create a PostgreSQL DB using pg8000.
- Commit 49ba768ed4d8d1b57acca6f5ffef8ecba13cc9fc extends the tests to test dropping a PostgreSQL DB using pg8000. The TC fails as intended to reproduce the error as can be seen [here](https://travis-ci.org/kvesteri/sqlalchemy-utils/jobs/478651095#L3302).
- The following commit adds support to drop a PostgreSQL DB using pg8000.