### PR TITLE
Import ABCs from collections.abc if possible

### DIFF
--- a/sqlalchemy_utils/functions/database.py
+++ b/sqlalchemy_utils/functions/database.py
@@ -1,4 +1,8 @@
-import collections
+try:
+    from collections.abc import Mapping, Sequence
+except ImportError:
+    from collections import Mapping, Sequence
+
 import itertools
 import os
 from copy import copy
@@ -167,7 +171,7 @@ def json_sql(value, scalars_to_json=True):
         def scalar_convert(a):
             return sa.func.to_json(sa.text(a))
 
-    if isinstance(value, collections.Mapping):
+    if isinstance(value, Mapping):
         return sa.func.json_build_object(
             *(
                 json_sql(v, scalars_to_json=False)
@@ -176,7 +180,7 @@ def json_sql(value, scalars_to_json=True):
         )
     elif isinstance(value, str):
         return scalar_convert("'{0}'".format(value))
-    elif isinstance(value, collections.Sequence):
+    elif isinstance(value, Sequence):
         return sa.func.json_build_array(
             *(
                 json_sql(v, scalars_to_json=False)

--- a/sqlalchemy_utils/generic.py
+++ b/sqlalchemy_utils/generic.py
@@ -1,4 +1,7 @@
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 import six
 import sqlalchemy as sa

--- a/sqlalchemy_utils/observer.py
+++ b/sqlalchemy_utils/observer.py
@@ -173,7 +173,12 @@ in the decorator.
 
 """
 import itertools
-from collections import defaultdict, Iterable, namedtuple
+from collections import defaultdict, namedtuple
+
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 import sqlalchemy as sa
 

--- a/sqlalchemy_utils/types/arrow.py
+++ b/sqlalchemy_utils/types/arrow.py
@@ -1,6 +1,10 @@
 from __future__ import absolute_import
 
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
+
 from datetime import datetime
 
 import six

--- a/sqlalchemy_utils/types/range.py
+++ b/sqlalchemy_utils/types/range.py
@@ -134,7 +134,11 @@ than 500.
 
 .. _intervals: https://github.com/kvesteri/intervals
 """
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
+
 from datetime import timedelta
 
 import six

--- a/sqlalchemy_utils/utils.py
+++ b/sqlalchemy_utils/utils.py
@@ -1,5 +1,9 @@
 import sys
-from collections import Iterable
+
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 import six
 


### PR DESCRIPTION
"`from collections import Iterable`" (or any other import of an ABC from `collections`) produces a `DeprecationWarning` under Python 3.7 with the message:

> Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working

This patch eliminates this warning by importing from `collections.abc` instead, falling back to `collections` only if that fails (i.e., if running under Python < 3.3).

Closes #367.