### PR TITLE
database_exists: don't connect to 'postgres' data base for database existence check

### DIFF
--- a/sqlalchemy_utils/functions/database.py
+++ b/sqlalchemy_utils/functions/database.py
@@ -469,11 +469,6 @@ def database_exists(url):
 
     url = copy(make_url(url))
     database = url.database
-    if url.drivername.startswith('postgres'):
-        url.database = 'postgres'
-    else:
-        url.database = None
-
     engine = sa.create_engine(url)
 
     if engine.dialect.name == 'postgresql':

--- a/sqlalchemy_utils/functions/database.py
+++ b/sqlalchemy_utils/functions/database.py
@@ -468,7 +468,7 @@ def database_exists(url):
         return header[:16] == b'SQLite format 3\x00'
 
     url = copy(make_url(url))
-    database = url.database
+    database, url.database = url.database, None
     engine = sa.create_engine(url)
 
     if engine.dialect.name == 'postgresql':


### PR DESCRIPTION
On our installation we don't have CONNECT permission for the data base called 'postgres'. Hence the function did not work. 

This has been introduced here (the if else branch probably made sense in drop and create, but it doesn't here in my opinion)

https://github.com/kvesteri/sqlalchemy-utils/commit/5d741c16662cde063e6930e7d3fe87b00ae9b8bb
https://github.com/kvesteri/sqlalchemy-utils/commit/d7f2905a39a02a2aa5b7b81640abe8cfd07e8771