### PR TITLE
Remove deprecation warnings

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -7,6 +7,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base, synonym_for
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm.session import close_all_sessions
 from sqlalchemy_utils import (
     aggregates,
     coercion_listener,
@@ -218,7 +219,7 @@ def session(request, engine, connection, Base, init_models):
 
     def teardown():
         aggregates.manager.reset()
-        session.close_all()
+        close_all_sessions()
         Base.metadata.drop_all(connection)
         remove_composite_listeners()
         connection.close()

--- a/conftest.py
+++ b/conftest.py
@@ -55,7 +55,7 @@ def mysql_db_user():
 
 @pytest.fixture
 def postgresql_dsn(postgresql_db_user, db_name):
-    return 'postgres://{0}@localhost/{1}'.format(postgresql_db_user, db_name)
+    return 'postgresql://{0}@localhost/{1}'.format(postgresql_db_user, db_name)
 
 
 @pytest.fixture

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ extras_require = {
         'psycopg2>=2.5.1',
         'pg8000>=1.12.4',
         'pytz>=2014.2',
-        'python-dateutil>=2.2',
+        'python-dateutil>=2.6',
         'pymysql',
         'flake8>=2.4.0',
         'isort>=4.2.2',

--- a/sqlalchemy_utils/functions/database.py
+++ b/sqlalchemy_utils/functions/database.py
@@ -438,13 +438,13 @@ def database_exists(url):
     Performs backend-specific testing to quickly determine if a database
     exists on the server. ::
 
-        database_exists('postgres://postgres@localhost/name')  #=> False
-        create_database('postgres://postgres@localhost/name')
-        database_exists('postgres://postgres@localhost/name')  #=> True
+        database_exists('postgresql://postgres@localhost/name')  #=> False
+        create_database('postgresql://postgres@localhost/name')
+        database_exists('postgresql://postgres@localhost/name')  #=> True
 
     Supports checking against a constructed URL as well. ::
 
-        engine = create_engine('postgres://postgres@localhost/name')
+        engine = create_engine('postgresql://postgres@localhost/name')
         database_exists(engine.url)  #=> False
         create_database(engine.url)
         database_exists(engine.url)  #=> True
@@ -523,7 +523,7 @@ def create_database(url, encoding='utf8', template=None):
     To create a database, you can pass a simple URL that would have
     been passed to ``create_engine``. ::
 
-        create_database('postgres://postgres@localhost/name')
+        create_database('postgresql://postgres@localhost/name')
 
     You may also pass the url from an existing engine. ::
 
@@ -598,7 +598,7 @@ def drop_database(url):
     Works similar to the :ref:`create_database` method in that both url text
     and a constructed url are accepted. ::
 
-        drop_database('postgres://postgres@localhost/name')
+        drop_database('postgresql://postgres@localhost/name')
         drop_database(engine.url)
 
     """

--- a/sqlalchemy_utils/types/timezone.py
+++ b/sqlalchemy_utils/types/timezone.py
@@ -38,10 +38,10 @@ class TimezoneType(types.TypeDecorator, ScalarCoercible):
         if backend == 'dateutil':
             try:
                 from dateutil.tz import tzfile
-                from dateutil.zoneinfo import gettz
+                from dateutil.zoneinfo import get_zonefile_instance
 
                 self.python_type = tzfile
-                self._to = gettz
+                self._to = get_zonefile_instance().zones.get
                 self._from = lambda x: six.text_type(x._filename)
 
             except ImportError:

--- a/tests/functions/test_database.py
+++ b/tests/functions/test_database.py
@@ -27,7 +27,7 @@ class TestDatabaseSQLiteMemory(object):
         assert database_exists(dsn)
 
 
-@pytest.mark.usefixture('sqlite_none_database_dsn')
+@pytest.mark.usefixtures('sqlite_none_database_dsn')
 class TestDatabaseSQLiteMemoryNoDatabaseString(object):
     def test_exists_memory_none_database(self, sqlite_none_database_dsn):
         assert database_exists(sqlite_none_database_dsn)

--- a/tests/functions/test_database.py
+++ b/tests/functions/test_database.py
@@ -75,7 +75,7 @@ class TestDatabasePostgres(DatabaseTest):
                 "TEMPLATE my_template"
             )
         )
-        dsn = 'postgres://{0}@localhost/db_test_sqlalchemy_util'.format(
+        dsn = 'postgresql://{0}@localhost/db_test_sqlalchemy_util'.format(
             postgresql_db_user
         )
         create_database(dsn, template='my_template')
@@ -108,7 +108,7 @@ class TestDatabasePostgresWithQuotedName(DatabaseTest):
                 'TEMPLATE "my-template"'
             )
         )
-        dsn = 'postgres://{0}@localhost/db_test_sqlalchemy-util'.format(
+        dsn = 'postgresql://{0}@localhost/db_test_sqlalchemy-util'.format(
             postgresql_db_user
         )
         create_database(dsn, template='my-template')
@@ -117,7 +117,7 @@ class TestDatabasePostgresWithQuotedName(DatabaseTest):
 class TestDatabasePostgresCreateDatabaseCloseConnection(object):
     def test_create_database_twice(self, postgresql_db_user):
         dsn_list = [
-            'postgres://{0}@localhost/db_test_sqlalchemy-util-a'.format(
+            'postgresql://{0}@localhost/db_test_sqlalchemy-util-a'.format(
                 postgresql_db_user
             ),
             'postgres://{0}@localhost/db_test_sqlalchemy-util-b'.format(


### PR DESCRIPTION
Resolving the deprecation warning reported by [`dateutil.zoneinfo.gettz`](https://dateutil.readthedocs.io/en/stable/zoneinfo.html#dateutil.zoneinfo.gettz) required bumping the required version of `python-dateutil` to at least 2.6.