### PR TITLE
fix depricated import

### DIFF
--- a/sqlalchemy_utils/utils.py
+++ b/sqlalchemy_utils/utils.py
@@ -1,5 +1,5 @@
 import sys
-from collections import Iterable
+from collections.abc import Iterable
 
 import six
 


### PR DESCRIPTION
 Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working