### PR TITLE
add hash method for PhoneNumber

### DIFF
--- a/sqlalchemy_utils/types/phone_number.py
+++ b/sqlalchemy_utils/types/phone_number.py
@@ -136,6 +136,9 @@ class PhoneNumber(BasePhoneNumber):
     def __unicode__(self):
         return self.national
 
+    def __hash__(self):
+        return hash(self.e164)
+
 
 class PhoneNumberType(types.TypeDecorator, ScalarCoercible):
     """


### PR DESCRIPTION
`PhoneNumberType` does not work with current SQLAlchemy because it tries to hash `PhoneNumber` when querying.

This PR implements hash function for PhoneNumber class.