### PR TITLE
Resolve ABCs deprecation warning

### DIFF
--- a/sqlalchemy_utils/utils.py
+++ b/sqlalchemy_utils/utils.py
@@ -1,5 +1,5 @@
 import sys
-from collections import Iterable
+from collections.abc import Iterable
 
 import six
 


### PR DESCRIPTION
Aims to resolve a deprecation warning.

```
  /usr/local/lib/python3.7/site-packages/sqlalchemy_utils/utils.py:2: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import Iterable

-- Docs: https://docs.pytest.org/en/latest/warnings.html
```