### PR TITLE
Resolve ABCs deprecation warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ addons:
 
 services:
   - docker
+  - mysql
 
 before_script:
   - psql -c 'create database sqlalchemy_utils_test;' -U postgres

--- a/sqlalchemy_utils/generic.py
+++ b/sqlalchemy_utils/generic.py
@@ -1,7 +1,7 @@
 try:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import Iterable
 except ImportError:  # For python 2.7 support
-    from collections import Mapping, Sequence
+    from collections import Iterable
 
 import six
 import sqlalchemy as sa

--- a/sqlalchemy_utils/generic.py
+++ b/sqlalchemy_utils/generic.py
@@ -1,4 +1,7 @@
-from collections.abc import Iterable
+try:
+    from collections.abc import Mapping, Sequence
+except ImportError:  # For python 2.7 support
+    from collections import Mapping, Sequence
 
 import six
 import sqlalchemy as sa

--- a/sqlalchemy_utils/generic.py
+++ b/sqlalchemy_utils/generic.py
@@ -1,4 +1,4 @@
-from collections import Iterable
+from collections.abc import Iterable
 
 import six
 import sqlalchemy as sa

--- a/sqlalchemy_utils/types/arrow.py
+++ b/sqlalchemy_utils/types/arrow.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import
 
 try:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import Iterable
 except ImportError:  # For python 2.7 support
-    from collections import Mapping, Sequence
+    from collections import Iterable
 from datetime import datetime
 
 import six

--- a/sqlalchemy_utils/types/arrow.py
+++ b/sqlalchemy_utils/types/arrow.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import
 
-from collections.abc import Iterable
+try:
+    from collections.abc import Mapping, Sequence
+except ImportError:  # For python 2.7 support
+    from collections import Mapping, Sequence
 from datetime import datetime
 
 import six

--- a/sqlalchemy_utils/types/arrow.py
+++ b/sqlalchemy_utils/types/arrow.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from collections import Iterable
+from collections.abc import Iterable
 from datetime import datetime
 
 import six

--- a/sqlalchemy_utils/types/range.py
+++ b/sqlalchemy_utils/types/range.py
@@ -134,7 +134,10 @@ than 500.
 
 .. _intervals: https://github.com/kvesteri/intervals
 """
-from collections.abc import Iterable
+try:
+    from collections.abc import Mapping, Sequence
+except ImportError:  # For python 2.7 support
+    from collections import Mapping, Sequence
 from datetime import timedelta
 
 import six

--- a/sqlalchemy_utils/types/range.py
+++ b/sqlalchemy_utils/types/range.py
@@ -135,9 +135,9 @@ than 500.
 .. _intervals: https://github.com/kvesteri/intervals
 """
 try:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import Iterable
 except ImportError:  # For python 2.7 support
-    from collections import Mapping, Sequence
+    from collections import Iterable
 from datetime import timedelta
 
 import six

--- a/sqlalchemy_utils/types/range.py
+++ b/sqlalchemy_utils/types/range.py
@@ -134,7 +134,7 @@ than 500.
 
 .. _intervals: https://github.com/kvesteri/intervals
 """
-from collections import Iterable
+from collections.abc import Iterable
 from datetime import timedelta
 
 import six

--- a/sqlalchemy_utils/utils.py
+++ b/sqlalchemy_utils/utils.py
@@ -1,8 +1,8 @@
 import sys
 try:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import Iterable
 except ImportError:  # For python 2.7 support
-    from collections import Mapping, Sequence
+    from collections import Iterable
 
 import six
 

--- a/sqlalchemy_utils/utils.py
+++ b/sqlalchemy_utils/utils.py
@@ -1,5 +1,5 @@
 import sys
-from collections import Iterable
+from collections.abc import Iterable
 
 import six
 

--- a/sqlalchemy_utils/utils.py
+++ b/sqlalchemy_utils/utils.py
@@ -1,5 +1,8 @@
 import sys
-from collections.abc import Iterable
+try:
+    from collections.abc import Mapping, Sequence
+except ImportError:  # For python 2.7 support
+    from collections import Mapping, Sequence
 
 import six
 


### PR DESCRIPTION
Aims to resolve a deprecation warning.

```
  /usr/local/lib/python3.7/site-packages/sqlalchemy_utils/utils.py:2: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import Iterable

-- Docs: https://docs.pytest.org/en/latest/warnings.html
```