### PR TITLE
generic_relationship: fix Comparator.is_type() behavior with aliased mapped classes

### DIFF
--- a/tests/generic_relationship/test_aliased.py
+++ b/tests/generic_relationship/test_aliased.py
@@ -1,0 +1,44 @@
+import pytest
+import sqlalchemy as sa
+
+from sqlalchemy_utils import generic_relationship
+
+
+@pytest.fixture
+def User(Base):
+    class User(Base):
+        __tablename__ = 'user'
+        id = sa.Column(sa.Integer, primary_key=True)
+    return User
+
+
+@pytest.fixture
+def Event(Base):
+    class Event(Base):
+        __tablename__ = 'event'
+        id = sa.Column(sa.Integer, primary_key=True)
+
+        object_type = sa.Column(sa.Unicode(255), name="objectType")
+        object_id = sa.Column(sa.Integer, nullable=False)
+
+        object = generic_relationship(object_type, object_id)
+    return Event
+
+
+@pytest.fixture
+def init_models(User, Event):
+    pass
+
+
+class TestGenericRelationship(object):
+
+    def test_compare_statement(self, session, User, Event):
+        event_alias = sa.orm.aliased(Event)
+
+        statemement_alias = event_alias.object.is_type(User)
+        statemement = Event.object.is_type(User)
+
+        assert (
+            statemement_alias.compile().string !=
+            statemement.compile().string
+        )


### PR DESCRIPTION
When mapped classes are aliased, Comparator.is_type() does not propagate the alias to the generated sql.

I don't know if my code makes 100% sense. I basically brought together some bits from sqlalchemy [RelationshipProperty.Comparator](https://github.com/sqlalchemy/sqlalchemy/blob/7e588aadaab27a53b226a4637be9b4022ab46956/lib/sqlalchemy/orm/relationships.py) and [this old but useful blogpost](https://techspot.zzzeek.org/category/sqlalchemy/5/) from zzzeek.

Thanks!