### PR TITLE
Add __str__ for Choice

### DIFF
--- a/sqlalchemy_utils/types/choice.py
+++ b/sqlalchemy_utils/types/choice.py
@@ -29,6 +29,9 @@ class Choice(object):
     def __unicode__(self):
         return six.text_type(self.value)
 
+    def __str__(self):
+        return six.ensure_str(self.__unicode__())
+
     def __repr__(self):
         return 'Choice(code={code}, value={value})'.format(
             code=self.code,


### PR DESCRIPTION
The `__unicode__` method isn't used in Python 3, so this restores the intended behaviour.