### PR TITLE
Fix the final place where not importing from collections.abc

### DIFF
--- a/sqlalchemy_utils/observer.py
+++ b/sqlalchemy_utils/observer.py
@@ -173,13 +173,18 @@ in the decorator.
 
 """
 import itertools
-from collections import defaultdict, Iterable, namedtuple
+from collections import defaultdict, namedtuple
 
 import sqlalchemy as sa
 
 from .functions import getdotattr, has_changes
 from .path import AttrPath
 from .utils import is_sequence
+
+try:
+    from collections.abc import Iterable
+except ImportError:  # For python 2.7 support
+    from collections import Iterable
 
 Callback = namedtuple('Callback', ['func', 'backref', 'fullpath'])
 


### PR DESCRIPTION
I believe this is the last place in the project missing the `from collections.abc` version of the import, for compatibility with Python 3.8.