### PR TITLE
Edit bug where non-class tables cannot work with make_order_by_deterministic

### DIFF
--- a/sqlalchemy_utils/functions/orm.py
+++ b/sqlalchemy_utils/functions/orm.py
@@ -412,6 +412,9 @@ def get_tables(mixed):
         return mixed.parent.tables
     elif isinstance(mixed, sa.orm.query._ColumnEntity):
         mixed = mixed.expr
+	
+        if isinstance(mixed, sa.Column):
+	    return [mixed.table]
 
     mapper = get_mapper(mixed)
 

--- a/sqlalchemy_utils/functions/orm.py
+++ b/sqlalchemy_utils/functions/orm.py
@@ -414,7 +414,7 @@ def get_tables(mixed):
         mixed = mixed.expr
 	
         if isinstance(mixed, sa.Column):
-	    return [mixed.table]
+            return [mixed.table]
 
     mapper = get_mapper(mixed)
 


### PR DESCRIPTION
This fixes an issue in which non-class defined tables raise a ValueError in make_order_by_deterministic because the  _ColumnEntity instance is converted into a Column instance, and then sent to get_mapper where it naturally fails because naturally no mapper will be found and thus the ValueError is raised. Once it is a Column instance it should return [mixed.table] as it would if it entered the get_tables function as one, and not have get_mapper called at all.