### PR TITLE
Using String instead of LargeBinary for impl of EncryptedType

### DIFF
--- a/sqlalchemy_utils/types/encrypted/encrypted_type.py
+++ b/sqlalchemy_utils/types/encrypted/encrypted_type.py
@@ -110,7 +110,7 @@ class AesEngine(EncryptionDecryptionBaseEngine):
         encryptor = self.cipher.encryptor()
         encrypted = encryptor.update(value) + encryptor.finalize()
         encrypted = base64.b64encode(encrypted)
-        return encrypted
+        return encrypted.decode('utf-8')
 
     def decrypt(self, value):
         if isinstance(value, six.text_type):
@@ -164,7 +164,7 @@ class AesGcmEngine(EncryptionDecryptionBaseEngine):
         encrypted = encryptor.update(value) + encryptor.finalize()
         assert len(encryptor.tag) == self.TAG_SIZE_BYTES
         encrypted = base64.b64encode(iv + encryptor.tag + encrypted)
-        return encrypted
+        return encrypted.decode('utf-8')
 
     def decrypt(self, value):
         if isinstance(value, six.text_type):
@@ -208,12 +208,12 @@ class FernetEngine(EncryptionDecryptionBaseEngine):
             value = str(value)
         value = value.encode()
         encrypted = self.fernet.encrypt(value)
-        return encrypted
+        return encrypted.decode('utf-8')
 
     def decrypt(self, value):
         if isinstance(value, six.text_type):
             value = str(value)
-        decrypted = self.fernet.decrypt(value)
+        decrypted = self.fernet.decrypt(value.encode())
         if not isinstance(decrypted, six.string_types):
             decrypted = decrypted.decode('utf-8')
         return decrypted
@@ -344,7 +344,7 @@ class EncryptedType(TypeDecorator, ScalarCoercible):
 
     """
 
-    impl = LargeBinary
+    impl = String
 
     def __init__(self, type_in=None, key=None,
                  engine=None, padding=None, **kwargs):

--- a/sqlalchemy_utils/types/encrypted/encrypted_type.py
+++ b/sqlalchemy_utils/types/encrypted/encrypted_type.py
@@ -4,7 +4,7 @@ import datetime
 import os
 
 import six
-from sqlalchemy.types import LargeBinary, String, TypeDecorator
+from sqlalchemy.types import String, TypeDecorator
 
 from sqlalchemy_utils.exceptions import ImproperlyConfigured
 from sqlalchemy_utils.types.encrypted.padding import PADDING_MECHANISM

--- a/tests/types/test_encrypted.py
+++ b/tests/types/test_encrypted.py
@@ -468,7 +468,7 @@ class TestAesGcmEngine(object):
         # 3rd char will be IV. Modify it
         POS = 3
         encrypted = encrypted[:POS] + \
-            (b'A' if encrypted[POS] != b'A' else b'B') + \
+            ('A' if encrypted[POS] != 'A' else 'B') + \
             encrypted[POS + 1:]
         with pytest.raises(InvalidCiphertextError):
             self.engine.decrypt(encrypted)
@@ -479,7 +479,7 @@ class TestAesGcmEngine(object):
         # 19th char will be tag. Modify it
         POS = 19
         encrypted = encrypted[:POS] + \
-            (b'A' if encrypted[POS] != b'A' else b'B') + \
+            ('A' if encrypted[POS] != 'A' else 'B') + \
             encrypted[POS + 1:]
         with pytest.raises(InvalidCiphertextError):
             self.engine.decrypt(encrypted)
@@ -490,7 +490,7 @@ class TestAesGcmEngine(object):
         # 43rd char will be ciphertext. Modify it
         POS = 43
         encrypted = encrypted[:POS] + \
-            (b'A' if encrypted[POS] != b'A' else b'B') + \
+            ('A' if encrypted[POS] != 'A' else 'B') + \
             encrypted[POS + 1:]
         with pytest.raises(InvalidCiphertextError):
             self.engine.decrypt(encrypted)


### PR DESCRIPTION
Closes #425

LargeBinary is problematic in python3 (see issue description). I recommend that we use `String` instead of `LargeBinary` as the impl for `EncryptedType`.

`self.fernet.encrypt()` and all other `encrypt()` methods in this class already return base64 encodings of the data, they are just formatted as `byte` instead of `str`. It does not make much sense to store them as binary because:

- encoding/decoding is problematic
- They are BASE64 (i.e. string) already

I manually tested this change by encoding and decoding strings using all three encryption engines (`AesEngine`, `AesGcmEngine`, `FernetEngine`) and everything works as expected. 

Additionally, I went ahead and included 

```
git+git://github.com/aicioara-forks/sqlalchemy-utils@0.36.1-fix-encrypted-type#egg=SQLAlchemy-Utils
```

In my `requirements.txt` and my entire flask application works as expected.

Happy to take feedback to make this perfect.