### PR TITLE
Add hash method to the phone number type

### DIFF
--- a/sqlalchemy_utils/types/phone_number.py
+++ b/sqlalchemy_utils/types/phone_number.py
@@ -136,6 +136,9 @@ class PhoneNumber(BasePhoneNumber):
     def __unicode__(self):
         return self.national
 
+    def __hash__(self):
+        return hash(self.e164)
+
 
 class PhoneNumberType(types.TypeDecorator, ScalarCoercible):
     """

--- a/tests/types/test_phonenumber.py
+++ b/tests/types/test_phonenumber.py
@@ -110,6 +110,13 @@ class TestPhoneNumber(object):
         else:
             assert str(number) == number.national
 
+    def test_phone_number_hash(self):
+        number1 = PhoneNumber('+821023456789')
+        number2 = PhoneNumber('+82 10-2345-6789')
+        assert hash(number1) == hash(number2)
+        assert hash(number1) == hash(number1.e164)
+        assert {number1} == {number2}
+
 
 @pytest.mark.skipif('types.phone_number.phonenumbers is None')
 class TestPhoneNumberType(object):


### PR DESCRIPTION
> PhoneNumberType does not work with current SQLAlchemy because it tries to hash PhoneNumber when querying.

> This PR implements hash function for PhoneNumber class.

Added unit test from #384.