### PR TITLE
Support for dictionary input in CompositeType

### DIFF
--- a/sqlalchemy_utils/types/pg_composite.py
+++ b/sqlalchemy_utils/types/pg_composite.py
@@ -49,6 +49,22 @@ Usage
         )
 
 
+Creation
+~~~~~~~~
+When creating CompositeType, you can either pass in a tuple or a dictionary.
+
+::
+    account1 = Account()
+    account1.balance = ('USD', 15)
+
+    account2 = Account()
+    account2.balance = {'currency': 'USD', 'balance': 15}
+
+    session.add(account1)
+    session.add(account2)
+    session.commit()
+
+
 Accessing fields
 ^^^^^^^^^^^^^^^^
 
@@ -207,16 +223,23 @@ class CompositeType(UserDefinedType, SchemaType):
         def process(value):
             if value is None:
                 return None
+
             processed_value = []
             for i, column in enumerate(self.columns):
+                current_value = (
+                    value.get(column.name)
+                    if isinstance(value, dict)
+                    else value[i]
+                )
+
                 if isinstance(column.type, TypeDecorator):
                     processed_value.append(
                         column.type.process_bind_param(
-                            value[i], dialect
+                            current_value, dialect
                         )
                     )
                 else:
-                    processed_value.append(value[i])
+                    processed_value.append(current_value)
             return self.type_cls(*processed_value)
         return process
 


### PR DESCRIPTION
Currently when creating a `CompositeType`, you can either pass in a tuple:

```py
account1 = Account()
account1.balance = ('USD', 15)
```

or instantiate it with `type_cls`:

```py
account2 = Account()
account2.balance = MoneyType.type_cls('USD', 15)
```

I would like to be able to pass in a dictionary for better integration with [Marshmallow](https://marshmallow-sqlalchemy.readthedocs.io/en/latest/index.html)

So hopefully this should be possible now:

```py
account1 = Account()
account1.balance = {'currency': 'USD', 'balance': 15}
```
