### PR TITLE
.travis.yml Add missing codecov upload script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,3 +35,6 @@ install:
 
 script:
   - tox
+
+after_success:
+  - curl -s https://codecov.io/bash | bash


### PR DESCRIPTION
Got it from https://docs.codecov.io/docs/supported-ci-providers

Then https://codecov.io/gh/kvesteri/sqlalchemy-utils won't be empty.