### PR TITLE
Set default generator to uuid.uuid4 in example

### DIFF
--- a/sqlalchemy_utils/types/uuid.py
+++ b/sqlalchemy_utils/types/uuid.py
@@ -22,7 +22,7 @@ class UUIDType(types.TypeDecorator, ScalarCoercible):
             __tablename__ = 'user'
 
             # Pass `binary=False` to fallback to CHAR instead of BINARY
-            id = sa.Column(UUIDType(binary=False), primary_key=True)
+            id = sa.Column(UUIDType(binary=False), primary_key=True, default=uuid.uuid4)
     """
     impl = types.BINARY(16)
 


### PR DESCRIPTION
Without a default generator to uuid.uuid4 you get an `IntegrityError: NOT NULL constraint failed` on the field using the UUIDType.

For example,  

```
sqlalchemy.exc.IntegrityError: (sqlite3.IntegrityError) NOT NULL constraint failed: users.uuid
```

and a warning,

```
.../lib/python3.8/site-packages/sqlalchemy/sql/crud.py:801: SA Warning: Column 'users.uuid' is marked as a member of the primary key for table 'users', but has no Python-side or server-side default generator indicated, nor does it indicate 'autoincrement=True' or 'nullable=True', and no explicit value is passed.  Primary key columns typically may not store NULL.
    util.warn(msg)
```