### PR TITLE
fix: export StringEncryptedType

### DIFF
--- a/sqlalchemy_utils/__init__.py
+++ b/sqlalchemy_utils/__init__.py
@@ -91,6 +91,7 @@ from .types import (  # noqa
     remove_composite_listeners,
     ScalarListException,
     ScalarListType,
+    StringEncryptedType,
     TimezoneType,
     TSVectorType,
     URLType,

--- a/sqlalchemy_utils/types/__init__.py
+++ b/sqlalchemy_utils/types/__init__.py
@@ -8,7 +8,7 @@ from .color import ColorType  # noqa
 from .country import CountryType  # noqa
 from .currency import CurrencyType  # noqa
 from .email import EmailType  # noqa
-from .encrypted.encrypted_type import EncryptedType  # noqa
+from .encrypted.encrypted_type import EncryptedType, StringEncryptedType  # noqa
 from .enriched_datetime.enriched_date_type import EnrichedDateType  # noqa
 from .ip_address import IPAddressType  # noqa
 from .json import JSONType  # noqa


### PR DESCRIPTION
The new type is not as easy to import as the deprecated EncryptedType class.