### PR TITLE
Add support for SQLAlchemy 1.4

### DIFF
--- a/sqlalchemy_utils/functions/database.py
+++ b/sqlalchemy_utils/functions/database.py
@@ -458,7 +458,11 @@ def database_exists(url):
         return header[:16] == b'SQLite format 3\x00'
 
     url = copy(make_url(url))
-    database, url.database = url.database, None
+    try:
+        database, url.database = url.database, None
+    except AttributeError:  #SQLalchemy 1.4: url is immutable
+        database = url.database
+        url.set(database=None)
     engine = sa.create_engine(url)
 
     if engine.dialect.name == 'postgresql':

--- a/sqlalchemy_utils/functions/orm.py
+++ b/sqlalchemy_utils/functions/orm.py
@@ -11,7 +11,10 @@ from sqlalchemy.orm import mapperlib
 from sqlalchemy.orm.attributes import InstrumentedAttribute
 from sqlalchemy.orm.exc import UnmappedInstanceError
 from sqlalchemy.orm.properties import ColumnProperty, RelationshipProperty
-from sqlalchemy.orm.query import _ColumnEntity
+try:
+    from sqlalchemy.orm.query import _ColumnEntity
+except ImportError:  # SQLAlchemy 1.4
+    from sqlalchemy.orm.context import _ColumnEntity
 from sqlalchemy.orm.session import object_session
 from sqlalchemy.orm.util import AliasedInsp
 


### PR DESCRIPTION
Import _ColumnEntity from sqlalchemy.orm.context if importing from
.query fails.

And while checking if database_exists, use url.set() as URL object is
now immutable.