### PR TITLE
issue-166 selecting encryption engine based on queryable parameter

### DIFF
--- a/docs/data_types.rst
+++ b/docs/data_types.rst
@@ -78,6 +78,8 @@ EncryptedType
 
 .. autoclass:: EncryptedType
 
+.. autoclass:: StringEncryptedType
+
 JSONType
 --------
 

--- a/tests/types/test_encrypted.py
+++ b/tests/types/test_encrypted.py
@@ -29,6 +29,7 @@ def User(Base, encryption_engine, test_key, padding_mechanism):
         username = sa.Column(EncryptedType(
             sa.Unicode,
             test_key,
+            isinstance(encryption_engine, AesEngine),
             encryption_engine,
             padding_mechanism)
         )
@@ -36,6 +37,7 @@ def User(Base, encryption_engine, test_key, padding_mechanism):
         access_token = sa.Column(EncryptedType(
             sa.String,
             test_key,
+            isinstance(encryption_engine, AesEngine),
             encryption_engine,
             padding_mechanism)
         )
@@ -43,6 +45,7 @@ def User(Base, encryption_engine, test_key, padding_mechanism):
         is_active = sa.Column(EncryptedType(
             sa.Boolean,
             test_key,
+            isinstance(encryption_engine, AesEngine),
             encryption_engine,
             padding_mechanism)
         )
@@ -50,6 +53,7 @@ def User(Base, encryption_engine, test_key, padding_mechanism):
         accounts_num = sa.Column(EncryptedType(
             sa.Integer,
             test_key,
+            isinstance(encryption_engine, AesEngine),
             encryption_engine,
             padding_mechanism)
         )
@@ -57,6 +61,7 @@ def User(Base, encryption_engine, test_key, padding_mechanism):
         phone = sa.Column(EncryptedType(
             PhoneNumberType,
             test_key,
+            isinstance(encryption_engine, AesEngine),
             encryption_engine,
             padding_mechanism)
         )
@@ -64,6 +69,7 @@ def User(Base, encryption_engine, test_key, padding_mechanism):
         color = sa.Column(EncryptedType(
             ColorType,
             test_key,
+            isinstance(encryption_engine, AesEngine),
             encryption_engine,
             padding_mechanism)
         )
@@ -71,6 +77,7 @@ def User(Base, encryption_engine, test_key, padding_mechanism):
         date = sa.Column(EncryptedType(
             sa.Date,
             test_key,
+            isinstance(encryption_engine, AesEngine),
             encryption_engine,
             padding_mechanism)
         )
@@ -78,6 +85,7 @@ def User(Base, encryption_engine, test_key, padding_mechanism):
         time = sa.Column(EncryptedType(
             sa.Time,
             test_key,
+            isinstance(encryption_engine, AesEngine),
             encryption_engine,
             padding_mechanism)
         )
@@ -85,6 +93,7 @@ def User(Base, encryption_engine, test_key, padding_mechanism):
         datetime = sa.Column(EncryptedType(
             sa.DateTime,
             test_key,
+            isinstance(encryption_engine, AesEngine),
             encryption_engine,
             padding_mechanism)
         )
@@ -92,6 +101,7 @@ def User(Base, encryption_engine, test_key, padding_mechanism):
         enum = sa.Column(EncryptedType(
             sa.Enum('One', name='user_enum_t'),
             test_key,
+            isinstance(encryption_engine, AesEngine),
             encryption_engine,
             padding_mechanism)
         )
@@ -99,6 +109,7 @@ def User(Base, encryption_engine, test_key, padding_mechanism):
         json = sa.Column(EncryptedType(
             JSONType,
             test_key,
+            isinstance(encryption_engine, AesEngine),
             encryption_engine,
             padding_mechanism)
         )
@@ -254,6 +265,7 @@ class EncryptedTypeTestCase(object):
             name = sa.Column(EncryptedType(
                 sa.Unicode,
                 lambda: self._team_key,
+                isinstance(encryption_engine, AesEngine),
                 encryption_engine,
                 padding_mechanism)
             )


### PR DESCRIPTION
issue-166 selecting encryption engine based on queryable parameter and documenting security considerations.

From issue #166 

- Removed user-configured engine selection and default to an internal selection of the Fernet engine.
- Add the `queryable` parameter that switches to the as-standing AesEngine.
- Add a warning block in the documentation that explains what the security risk is.
- Make clear in the documentation that EncryptedType inherits from StringEncryptedType.
- Add docstring of StringEncryptedType to the documentation.
- Add notes about engines to StringEncryptedType docstring.
- Update StringEncryptedType docstring to not reference EncryptedType.
- Explain in the docstring of each engine whether searching is possible and if it is secure.