### PR TITLE
Handle missing pymysql import

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -7,6 +7,12 @@ from sqlalchemy_utils import (
     refresh_materialized_view
 )
 
+pymysql = None
+try:
+    import pymysql  # noqa
+except ImportError:
+    pass
+
 
 @pytest.fixture
 def Article(Base, User):
@@ -171,6 +177,7 @@ class TestPostgresTrivialView(SupportsCascade, SupportsNoCascade):
     pass
 
 
+@pytest.mark.skipif('pymysql is None')
 @pytest.mark.usefixtures('mysql_dsn')
 class TestMySqlTrivialView(SupportsCascade, SupportsNoCascade):
     pass

--- a/tests/types/test_weekdays.py
+++ b/tests/types/test_weekdays.py
@@ -6,6 +6,12 @@ from sqlalchemy_utils import i18n
 from sqlalchemy_utils.primitives import WeekDays
 from sqlalchemy_utils.types import WeekDaysType
 
+pymysql = None
+try:
+    import pymysql  # noqa
+except ImportError:
+    pass
+
 
 @pytest.fixture
 def Schedule(Base):
@@ -59,6 +65,7 @@ class TestWeekDaysTypeOnPostgres(WeekDaysTypeTestCase):
     pass
 
 
+@pytest.mark.skipif('pymysql is None')
 @pytest.mark.usefixtures('mysql_dsn')
 class TestWeekDaysTypeOnMySQL(WeekDaysTypeTestCase):
     pass


### PR DESCRIPTION
This applies the same fix (no modification) already present in `tests/functions/database.py` ([here](https://github.com/kvesteri/sqlalchemy-utils/blob/master/tests/functions/test_database.py#L8) and [here](https://github.com/kvesteri/sqlalchemy-utils/blob/master/tests/functions/test_database.py#L44)).

This fixes local test runs on systems where pymysql, as well as mysql, are not installed.

Summary of edits:
1. Wrap import of pymysql package in try/except; 
2. Skip test if pymysql is missing.