### PR TITLE
selectable.c -> selectable.selected_columns

### DIFF
--- a/sqlalchemy_utils/view.py
+++ b/sqlalchemy_utils/view.py
@@ -53,7 +53,9 @@ def create_table_from_selectable(
     # https://docs.sqlalchemy.org/en/14/core/selectable.html#sqlalchemy.sql.expression.SelectBase.c
     # is waaaaay ambiguous (ie, "this attribute"). anyway looks like
     # 1.3 Select doesn't have subquery() so...
-    if hasattr(selectable, 'subquery'):
+    if hasattr(selectable, 'selected_columns'):
+        cols = selectable.selected_columns
+    elif hasattr(selectable, 'subquery'):
         cols = selectable.subquery().c
     else:
         cols = selectable.c

--- a/sqlalchemy_utils/view.py
+++ b/sqlalchemy_utils/view.py
@@ -48,6 +48,7 @@ def create_table_from_selectable(
         metadata = sa.MetaData()
     if aliases is None:
         aliases = {}
+    cols = selectable.selected_columns
     args = [
         sa.Column(
             c.name,
@@ -55,13 +56,13 @@ def create_table_from_selectable(
             key=aliases.get(c.name, c.name),
             primary_key=c.primary_key
         )
-        for c in selectable.c
+        for c in cols
     ] + indexes
     table = sa.Table(name, metadata, *args)
 
-    if not any([c.primary_key for c in selectable.c]):
+    if not any([c.primary_key for c in cols]):
         table.append_constraint(
-            PrimaryKeyConstraint(*[c.name for c in selectable.c])
+            PrimaryKeyConstraint(*[c.name for c in cols])
         )
     return table
 

--- a/sqlalchemy_utils/view.py
+++ b/sqlalchemy_utils/view.py
@@ -48,7 +48,12 @@ def create_table_from_selectable(
         metadata = sa.MetaData()
     if aliases is None:
         aliases = {}
-    cols = selectable.selected_columns
+
+    # whoa doggie, the deprecation notice in
+    # https://docs.sqlalchemy.org/en/14/core/selectable.html#sqlalchemy.sql.expression.SelectBase.c
+    # is waaaaay ambiguous (ie, "this attribute").
+    cols = selectable.subquery().c
+
     args = [
         sa.Column(
             c.name,

--- a/sqlalchemy_utils/view.py
+++ b/sqlalchemy_utils/view.py
@@ -51,8 +51,12 @@ def create_table_from_selectable(
 
     # whoa doggie, the deprecation notice in
     # https://docs.sqlalchemy.org/en/14/core/selectable.html#sqlalchemy.sql.expression.SelectBase.c
-    # is waaaaay ambiguous (ie, "this attribute").
-    cols = selectable.subquery().c
+    # is waaaaay ambiguous (ie, "this attribute"). anyway looks like
+    # 1.3 Select doesn't have subquery() so...
+    if hasattr(selectable, 'subquery'):
+        cols = selectable.subquery().c
+    else:
+        cols = selectable.c
 
     args = [
         sa.Column(


### PR DESCRIPTION
Hi, I was getting deprecation errors in my tests with `sa` 1.4.5; figured I might as well share this little patch with you.

Note I couldn't run your test suite because of that call to a missing `sqlalchemy.orm.query._ColumnEntity`, and I haven't the foggiest how to fix that so I couldn't test this.