### PR TITLE
Adding default_engine Class var

### DIFF
--- a/sqlalchemy_utils/types/encrypted/encrypted_type.py
+++ b/sqlalchemy_utils/types/encrypted/encrypted_type.py
@@ -349,6 +349,7 @@ class StringEncryptedType(TypeDecorator, ScalarCoercible):
     """
 
     impl = String
+    default_engine = AesEngine
 
     def __init__(self, type_in=None, key=None,
                  engine=None, padding=None, **kwargs):
@@ -366,7 +367,7 @@ class StringEncryptedType(TypeDecorator, ScalarCoercible):
         self.underlying_type = type_in
         self._key = key
         if not engine:
-            engine = AesEngine
+            engine = self.default_engine
         self.engine = engine()
         if isinstance(self.engine, AesEngine):
             self.engine._set_padding_mechanism(padding)


### PR DESCRIPTION
Adds new class variable `default_engine` to `StringEncryptedType` to allow for overriding of default behavior. Currently, `StringEncryptedType`'s ctor is hard-coded to utilize the `AesEngine` if no other engine is specified. This PR allows the default engine to be configured during app bootstrap.