### PR TITLE
Disable universal wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal = 1
-
 [flake8]
 exclude =
     .eggs


### PR DESCRIPTION
As of 0.37.0 Python 2 is no longer supported, and [universal wheels](https://packaging.python.org/guides/distributing-packages-using-setuptools/#universal-wheels) can no longer be used for distribution.