### PR TITLE
instant_defaults_listener should keep the constructor-supplied kwargs…

### DIFF
--- a/sqlalchemy_utils/listeners.py
+++ b/sqlalchemy_utils/listeners.py
@@ -22,6 +22,11 @@ def coercion_listener(mapper, class_):
 
 
 def instant_defaults_listener(target, args, kwargs):
+    # insertion order of kwargs matters
+    # copy and clear so that we can add back later at the end of the dict
+    original = kwargs.copy()
+    kwargs.clear()
+
     for key, column in sa.inspect(target.__class__).columns.items():
         if (
             hasattr(column, 'default') and
@@ -32,6 +37,9 @@ def instant_defaults_listener(target, args, kwargs):
                 kwargs[key] = column.default.arg(target)
             else:
                 kwargs[key] = column.default.arg
+
+    # supersede w/initial in case target uses setters overriding defaults
+    kwargs.update(original)
 
 
 def force_auto_coercion(mapper=None):

--- a/sqlalchemy_utils/listeners.py
+++ b/sqlalchemy_utils/listeners.py
@@ -30,8 +30,7 @@ def instant_defaults_listener(target, args, kwargs):
     for key, column in sa.inspect(target.__class__).columns.items():
         if (
             hasattr(column, 'default') and
-            column.default is not None and
-            key not in kwargs
+            column.default is not None
         ):
             if callable(column.default.arg):
                 kwargs[key] = column.default.arg(target)

--- a/tests/test_instant_defaults_listener.py
+++ b/tests/test_instant_defaults_listener.py
@@ -15,6 +15,16 @@ def Article(Base):
         id = sa.Column(sa.Integer, primary_key=True)
         name = sa.Column(sa.Unicode(255), default='Some article')
         created_at = sa.Column(sa.DateTime, default=datetime.now)
+        _byline = sa.Column(sa.Unicode(255), default='Default byline')
+
+        @property
+        def byline(self):
+            return self._byline
+
+        @byline.setter
+        def byline(self, value):
+            self._byline = value
+
     return Article
 
 
@@ -26,3 +36,7 @@ class TestInstantDefaultListener:
     def test_callables_as_defaults(self, Article):
         article = Article()
         assert isinstance(article.created_at, datetime)
+
+    def test_override_default_with_setter_function(self, Article):
+        article = Article(byline='provided byline')
+        assert article.byline == 'provided byline'


### PR DESCRIPTION
… at the end of the ordered dict, in case setter funcs are used to override standard column defaults.

fixes #515 