### PR TITLE
 Drop `anyjson` dependency to fix builds 

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,7 +2,7 @@ name: Python linting
 on: [push, pull_request]
 jobs:
   test:
-    name: Test
+    name: Lint
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ extras_require = {
         'isort>=4.2.2',
         'pyodbc',
     ],
-    'anyjson': ['anyjson>=0.3.3'],
     'babel': ['Babel>=1.3'],
     'arrow': ['arrow>=0.3.4'],
     'pendulum': ['pendulum>=2.0.5'],

--- a/sqlalchemy_utils/types/json.py
+++ b/sqlalchemy_utils/types/json.py
@@ -1,16 +1,10 @@
 from __future__ import absolute_import
 
+import json
+
 import six
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql.base import ischema_names
-
-from ..exceptions import ImproperlyConfigured
-
-json = None
-try:
-    import anyjson as json
-except ImportError:
-    import json as json
 
 try:
     from sqlalchemy.dialects.postgresql import JSON
@@ -58,10 +52,6 @@ class JSONType(sa.types.TypeDecorator):
     cache_ok = True
 
     def __init__(self, *args, **kwargs):
-        if json is None:
-            raise ImproperlyConfigured(
-                'JSONType needs anyjson package installed.'
-            )
         super(JSONType, self).__init__(*args, **kwargs)
 
     def load_dialect_impl(self, dialect):


### PR DESCRIPTION
`anyjson` is Python 2 only and requires `2to3`, which is not supported by `setuptools` anymore (https://setuptools.pypa.io/en/latest/history.html#v58-0-0).