### PR TITLE
Allow for arbitrary Table keyword arguments in create_table_from_selectable

### DIFF
--- a/sqlalchemy_utils/view.py
+++ b/sqlalchemy_utils/view.py
@@ -42,7 +42,8 @@ def create_table_from_selectable(
     selectable,
     indexes=None,
     metadata=None,
-    aliases=None
+    aliases=None,
+    **kwargs
 ):
     if indexes is None:
         indexes = []
@@ -59,7 +60,7 @@ def create_table_from_selectable(
         )
         for c in get_columns(selectable)
     ] + indexes
-    table = sa.Table(name, metadata, *args)
+    table = sa.Table(name, metadata, *args, **kwargs)
 
     if not any([c.primary_key for c in get_columns(selectable)]):
         table.append_constraint(


### PR DESCRIPTION
This is a very simple PR that allows for any of the [Table keyword arguments](https://docs.sqlalchemy.org/en/14/core/metadata.html#sqlalchemy.schema.Table) to be passed through the create_table_from_selectable method through to the table that gets generated.

An example of how this could be used is to allow the table to be generated in a specific schema:
```python
table = create_table_from_selectable(selectable=s, schema="my_schema")
```

