### PR TITLE
wip: Avoid sqlalchemy URL deprecation warning

### DIFF
--- a/sqlalchemy_utils/functions/database.py
+++ b/sqlalchemy_utils/functions/database.py
@@ -480,7 +480,6 @@ def database_exists(url):
 
     """
 
-    url = copy(make_url(url))
     database = url.database
     dialect_name = url.get_dialect().name
     engine = None
@@ -546,7 +545,6 @@ def create_database(url, encoding='utf8', template=None):
     other database engines should be supported.
     """
 
-    url = copy(make_url(url))
     database = url.database
     dialect_name = url.get_dialect().name
     dialect_driver = url.get_dialect().driver
@@ -613,7 +611,6 @@ def drop_database(url):
 
     """
 
-    url = copy(make_url(url))
     database = url.database
     dialect_name = url.get_dialect().name
     dialect_driver = url.get_dialect().driver


### PR DESCRIPTION
> sqlalchemy.exc.SADeprecationWarning: Calling URL() directly is deprecated and will be disabled in a future release.  The public constructor for URL is now the URL.create() method.

Not sure what happens with sqlalchemy 1.3 - this PR is mostly to run the test suite