### PR TITLE
Fix ignored test cases

### DIFF
--- a/tests/types/test_date_range.py
+++ b/tests/types/test_date_range.py
@@ -42,7 +42,7 @@ def init_models(Booking):
 
 
 @pytest.mark.skipif('intervals is None')
-class DateRangeTestCase:
+class TestDateRange:
     def test_nullify_range(self, create_booking):
         booking = create_booking(None)
         assert booking.during is None


### PR DESCRIPTION
Tests under this class seem not to be run due to [pytest discovery rules](https://docs.pytest.org/en/6.2.x/goodpractices.html#conventions-for-python-test-discovery), which requires classes to be prefixed with `Test`.

This also seems to be hiding potential problems with non-PostgreSQL database systems.