### PR TITLE
Fix cache_ok on ScalarCoercible subclasses

### DIFF
--- a/sqlalchemy_utils/types/scalar_coercible.py
+++ b/sqlalchemy_utils/types/scalar_coercible.py
@@ -1,6 +1,4 @@
 class ScalarCoercible:
-    cache_ok = True
-
     def _coerce(self, value):
         raise NotImplementedError
 

--- a/tests/types/test_date_range.py
+++ b/tests/types/test_date_range.py
@@ -82,6 +82,12 @@ class DateRangeTestCase:
         assert booking.during.lower == datetime(2015, 1, 1).date()
         assert booking.during.upper == datetime(2015, 1, 1).date()
 
+    def test_compilation(self, session, Booking):
+        query = sa.select([Booking.during])
+
+        # the type should be cacheable and not throw exception
+        session.execute(query)
+
 
 @pytest.mark.usefixtures('postgresql_dsn')
 class TestDateRangeOnPostgres(DateRangeTestCase):

--- a/tests/types/test_datetime_range.py
+++ b/tests/types/test_datetime_range.py
@@ -82,6 +82,12 @@ class DateTimeRangeTestCase:
         assert booking.during.lower == datetime(2015, 1, 1)
         assert booking.during.upper == datetime(2015, 1, 1)
 
+    def test_compilation(self, session, Booking):
+        query = sa.select([Booking.during])
+
+        # the type should be cacheable and not throw exception
+        session.execute(query)
+
 
 @pytest.mark.usefixtures('postgresql_dsn')
 class TestDateTimeRangeOnPostgres(DateTimeRangeTestCase):

--- a/tests/types/test_int_range.py
+++ b/tests/types/test_int_range.py
@@ -100,6 +100,12 @@ class NumberRangeTestCase(object):
         assert building.persons_at_night.lower == 15
         assert building.persons_at_night.upper == 15
 
+    def test_compilation(self, session, Building):
+        query = sa.select([Building.persons_at_night])
+
+        # the type should be cacheable and not throw exception
+        session.execute(query)
+
 
 @pytest.mark.usefixtures('postgresql_dsn')
 class TestIntRangeTypeOnPostgres(NumberRangeTestCase):

--- a/tests/types/test_locale.py
+++ b/tests/types/test_locale.py
@@ -59,3 +59,9 @@ class TestLocaleType(object):
         clause = User.locale == 'en_US'
         compiled = str(clause.compile(compile_kwargs={'literal_binds': True}))
         assert compiled == '"user".locale = \'en_US\''
+
+    def test_compilation(self, User, session):
+        query = sa.select([User.locale])
+
+        # the type should be cacheable and not throw exception
+        session.execute(query)

--- a/tests/types/test_numeric_range.py
+++ b/tests/types/test_numeric_range.py
@@ -89,6 +89,12 @@ class NumericRangeTestCase(object):
         assert car.price_range.lower == 15
         assert car.price_range.upper == 15
 
+    def test_compilation(self, session, Car):
+        query = sa.select([Car.price_range])
+
+        # the type should be cacheable and not throw exception
+        session.execute(query)
+
 
 @pytest.mark.usefixtures('postgresql_dsn')
 class TestNumericRangeOnPostgres(NumericRangeTestCase):

--- a/tests/types/test_uuid.py
+++ b/tests/types/test_uuid.py
@@ -59,6 +59,7 @@ class TestUUIDType(object):
 
     def test_compilation(self, User, session):
         query = sa.select([User.id])
+
         # the type should be cacheable and not throw exception
         session.execute(query)
 


### PR DESCRIPTION
Almost all of the `ScalarCoercible` subclasses still produced the warning about `cache_ok`. The `cache_ok` have been set on the `ScalarCoercible` instead of each final type class, as described in SQLAlchemy docs, see https://docs.sqlalchemy.org/en/14/errors.html#assertion-attributes-for-caching.