### PR TITLE
Avoided deprecation warning for URL in SQLAlchemy 1.4+.

### DIFF
--- a/sqlalchemy_utils/functions/database.py
+++ b/sqlalchemy_utils/functions/database.py
@@ -438,6 +438,7 @@ def _set_url_database(url: sa.engine.url.URL, database):
             query=url.query
         )
     else:  # SQLAlchemy <1.4
+        url = copy(url)
         url.database = database
         ret = url
     assert ret.database == database, ret
@@ -480,7 +481,7 @@ def database_exists(url):
 
     """
 
-    url = copy(make_url(url))
+    url = make_url(url)
     database = url.database
     dialect_name = url.get_dialect().name
     engine = None
@@ -546,7 +547,7 @@ def create_database(url, encoding='utf8', template=None):
     other database engines should be supported.
     """
 
-    url = copy(make_url(url))
+    url = make_url(url)
     database = url.database
     dialect_name = url.get_dialect().name
     dialect_driver = url.get_dialect().driver
@@ -613,7 +614,7 @@ def drop_database(url):
 
     """
 
-    url = copy(make_url(url))
+    url = make_url(url)
     database = url.database
     dialect_name = url.get_dialect().name
     dialect_driver = url.get_dialect().driver

--- a/sqlalchemy_utils/functions/database.py
+++ b/sqlalchemy_utils/functions/database.py
@@ -427,16 +427,9 @@ def _set_url_database(url: sa.engine.url.URL, database):
     :param database: New database to set.
 
     """
-    if hasattr(sa.engine, 'URL'):
-        ret = sa.engine.URL.create(
-            drivername=url.drivername,
-            username=url.username,
-            password=url.password,
-            host=url.host,
-            port=url.port,
-            database=database,
-            query=url.query
-        )
+    if hasattr(url, '_replace'):
+        # Cannot use URL.set() as database may need to be set to None.
+        ret = url._replace(database=database)
     else:  # SQLAlchemy <1.4
         url = copy(url)
         url.database = database


### PR DESCRIPTION
Closes #557 which didn't take the following into consideration:

- Still need `make_url()` to convert connection strings to `URL`.
- Still need `copy()` for SQLAlchemy < 1.4 where `URL` is mutable.

Note that SQLAlchemy has implemented `__copy__` and `__deepcopy__` so that `URL.create()` is used instead of `URL()`:

- https://github.com/sqlalchemy/sqlalchemy/issues/7400

Although this patch is only required for SQLAlchemy >=1.4,<1.4.28 it makes sense to avoid copying unnecessarily.