### PR TITLE
Update docs copyright years

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'SQLAlchemy-Utils'
-copyright = u'2013, Konsta Vesterinen'
+copyright = u'2013-2022, Konsta Vesterinen'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
I noticed this while reviewing the documentation and worried that I was either

* Looking at an old version of the documentation, or
* The project hadn't been updated in a long time

This metadata update asserts copyright and may help confirm the docs are maintained.

Thanks for your work on sqlalchemy-utils!