### PR TITLE
Fix double-quoted UUID's in sqlalchemy >= 1.4.30

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,8 @@
 [tox]
-envlist = py36, py37, py38, py39, lint
+envlist =
+    py{36, 37, 38}-sqlalchemy{13, 14}
+    py39-sqlalchemy{13, 14, 1_4_29}
+    lint
 
 [testenv]
 commands =
@@ -9,6 +12,9 @@ deps =
     pytest-cov
     sqlalchemy13: SQLAlchemy[postgresql_pg8000]>=1.3,<1.4
     sqlalchemy14: SQLAlchemy>=1.4,<1.5
+    ; It's necessary to test against specific sqlalchemy versions.
+    ; sqlalchemy 1.4.30 introduced UUID literal quoting. See #580.
+    sqlalchemy1_4_29: SQLAlchemy==1.4.29
 passenv =
     SQLALCHEMY_UTILS_TEST_DB
     SQLALCHEMY_UTILS_TEST_POSTGRESQL_USER


### PR DESCRIPTION
Fixes #580.

> ## Note
>
> This PR introduces a change in the tox testing.
>
> More than just adding sqlalchemy 1.4.29 as an environment dependency, it helps enforce that the cross-combination of Python versions and sqlalchemy versions are tested _by default_ (see the changes to `envlist`). For example, running tox without arguments will now run Python 3.6 through 3.8 with both sqlalchemy 1.3 and 1.4 (a total of 6 combinations).
>
> This may have implications for Github CI if it simply runs tox without environments specified.