### PR TITLE
Prevent cockroachdb `create_database()` / `drop_database()` crashes

### DIFF
--- a/sqlalchemy_utils/functions/database.py
+++ b/sqlalchemy_utils/functions/database.py
@@ -555,6 +555,8 @@ def create_database(url, encoding='utf8', template=None):
         url = _set_url_database(url, database="postgres")
     elif dialect_name == 'mssql':
         url = _set_url_database(url, database="master")
+    elif dialect_name == 'cockroachdb':
+        url = _set_url_database(url, database="defaultdb")
     elif not dialect_name == 'sqlite':
         url = _set_url_database(url, database=None)
 
@@ -622,6 +624,8 @@ def drop_database(url):
         url = _set_url_database(url, database="postgres")
     elif dialect_name == 'mssql':
         url = _set_url_database(url, database="master")
+    elif dialect_name == 'cockroachdb':
+        url = _set_url_database(url, database="defaultdb")
     elif not dialect_name == 'sqlite':
         url = _set_url_database(url, database=None)
 


### PR DESCRIPTION
@muslimbeibituly please try this out when you have an opportunity. I tested three functions locally and it seems to be working without crashing:

* `create_database()`
* `database_exists()`
* `drop_database()`

This doesn't mean everything is perfect, it just means I was able to avoid crashes with the patch in this PR.

@kvesteri I'd love to have your input how to add unit tests for cockroachdb. I discovered that [they offer a standalone open source Linux binary](https://www.cockroachlabs.com/docs/stable/install-cockroachdb-linux.html) that might be usable in the GitHub CI environment. Unfortunately, as it stands, this PR doesn't yet have unit tests.