### PR TITLE
Fix URL-related DeprecationWarnings

### DIFF
--- a/sqlalchemy_utils/functions/database.py
+++ b/sqlalchemy_utils/functions/database.py
@@ -438,6 +438,7 @@ def _set_url_database(url: sa.engine.url.URL, database):
             query=url.query
         )
     else:  # SQLAlchemy <1.4
+        url = copy(url)
         url.database = database
         ret = url
     assert ret.database == database, ret
@@ -480,7 +481,7 @@ def database_exists(url):
 
     """
 
-    url = copy(make_url(url))
+    url = make_url(url)
     database = url.database
     dialect_name = url.get_dialect().name
     engine = None
@@ -546,7 +547,7 @@ def create_database(url, encoding='utf8', template=None):
     other database engines should be supported.
     """
 
-    url = copy(make_url(url))
+    url = make_url(url)
     database = url.database
     dialect_name = url.get_dialect().name
     dialect_driver = url.get_dialect().driver
@@ -613,7 +614,7 @@ def drop_database(url):
 
     """
 
-    url = copy(make_url(url))
+    url = make_url(url)
     database = url.database
     dialect_name = url.get_dialect().name
     dialect_driver = url.get_dialect().driver

--- a/sqlalchemy_utils/functions/database.py
+++ b/sqlalchemy_utils/functions/database.py
@@ -427,16 +427,9 @@ def _set_url_database(url: sa.engine.url.URL, database):
     :param database: New database to set.
 
     """
-    if hasattr(sa.engine, 'URL'):
-        ret = sa.engine.URL.create(
-            drivername=url.drivername,
-            username=url.username,
-            password=url.password,
-            host=url.host,
-            port=url.port,
-            database=database,
-            query=url.query
-        )
+    if hasattr(url, '_replace'):
+        # Cannot use URL.set() as database may need to be set to None.
+        ret = url._replace(database=database)
     else:  # SQLAlchemy <1.4
         url = copy(url)
         url.database = database

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,8 @@ deps =
     sqlalchemy13: SQLAlchemy[postgresql_pg8000]>=1.3,<1.4
     sqlalchemy14: SQLAlchemy>=1.4,<1.5
     ; It's necessary to test against specific sqlalchemy versions.
+    ; sqlalchemy <1.4.28 threw a DeprecationWarning when copying a URL. See #573.
+    sqlalchemy1_4_27: SQLAlchemy==1.4.27
     ; sqlalchemy 1.4.30 introduced UUID literal quoting. See #580.
     sqlalchemy1_4_29: SQLAlchemy==1.4.29
 passenv =
@@ -32,3 +34,6 @@ skip_install = True
 deps =
     flake8>=3.7.9
     isort>=4.3.21
+
+[pytest]
+filterwarnings = error


### PR DESCRIPTION
This introduces a change to `tox.ini` that escalates warnings to errors, then cherry-picks commits written by @ngnpope in #573.

@kvesteri, to reproduce, follow these steps:

```sh
# Add my fork as a remote and fetch from it.
git add remote kurtmckee git@github.com:kurtmckee/sqlalchemy-utils.git
git fetch kurtmckee

# Checkout the commit that escalates existing warnings to errors.
# Then, run tox with sqlalchemy pinned to version 1.4.27.
git checkout 7f06c93
tox -e py39-sqlalchemy1_4_27

# Demonstrate the warnings no longer exist with @ngnpope's commits.
git checkout 8516a37
tox -e py39-sqlalchemy1_4_27
```

If desired, I can add a final commit to this chain that turns off the escalation of warnings to errors. Just let me know.