### PR TITLE
Add stacklevel to display warning with appropriate line.

### DIFF
--- a/sqlalchemy_utils/types/encrypted/encrypted_type.py
+++ b/sqlalchemy_utils/types/encrypted/encrypted_type.py
@@ -462,7 +462,7 @@ class EncryptedType(StringEncryptedType):
             "The 'EncryptedType' class will change implementation from "
             "'LargeBinary' to 'String' in a future version. Use "
             "'StringEncryptedType' to use the 'String' implementation.",
-            DeprecationWarning)
+            DeprecationWarning, stacklevel=2)
         super().__init__(*args, **kwargs)
 
     def process_bind_param(self, value, dialect):


### PR DESCRIPTION
Adding `stacklevel` ensures the appropriate place where `EncryptedType` is initialized is mentioned in the deprecation warning instead of the line in sqlalchemy_utils. Example as below

https://docs.python.org/3/library/warnings.html#warnings.warn

```python
import warnings


def foo():
    warnings.warn("foo is deprecated", DeprecationWarning, stacklevel=2)


def bar():
    warnings.warn("bar is deprecated", DeprecationWarning)


foo()
bar()
```

```python
(py38-venv) ➜  sqlalchemy-utils git:(fix-stacklevel) python -Wall /tmp/a.py       
/tmp/a.py:12: DeprecationWarning: foo is deprecated
  foo()
/tmp/a.py:9: DeprecationWarning: bar is deprecated
  warnings.warn("bar is deprecated", DeprecationWarning)
```