### PR TITLE
Ignore deprecation warnings caused by backports.zoneinfo

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -44,3 +44,5 @@ filterwarnings =
     ; Ignore ResourceWarnings caused by unclosed sockets in pg8000.
     ; These are caught and re-raised as pytest.PytestUnraisableExceptionWarnings.
     ignore:Exception ignored:pytest.PytestUnraisableExceptionWarning
+    ; Ignore DeprecationWarnings caused by pg8000.
+    ignore:distutils Version classes are deprecated.:DeprecationWarning

--- a/tox.ini
+++ b/tox.ini
@@ -41,3 +41,6 @@ filterwarnings =
     ; Ignore DeprecationWarnings caused by backports.zoneinfo (Python 3.6).
     ignore:open_text is deprecated. Use files\(\) instead.:DeprecationWarning
     ignore:open_binary is deprecated. Use files\(\) instead.:DeprecationWarning
+    ; Ignore ResourceWarnings caused by unclosed sockets in pg8000.
+    ; These are caught and re-raised as pytest.PytestUnraisableExceptionWarnings.
+    ignore:Exception ignored:pytest.PytestUnraisableExceptionWarning

--- a/tox.ini
+++ b/tox.ini
@@ -36,4 +36,8 @@ deps =
     isort>=4.3.21
 
 [pytest]
-filterwarnings = error
+filterwarnings =
+    error
+    ; Ignore DeprecationWarnings caused by backports.zoneinfo (Python 3.6).
+    ignore:open_text is deprecated. Use files\(\) instead.:DeprecationWarning
+    ignore:open_binary is deprecated. Use files\(\) instead.:DeprecationWarning


### PR DESCRIPTION
This addresses the warnings that are now escalated to errors during unit testing.

Fixes #590