### PR TITLE
add schema to create_view() and create_materialized_view()

### DIFF
--- a/sqlalchemy_utils/view.py
+++ b/sqlalchemy_utils/view.py
@@ -6,17 +6,21 @@ from sqlalchemy_utils.functions import get_columns
 
 
 class CreateView(DDLElement):
-    def __init__(self, name, selectable, materialized=False):
+    def __init__(self, name, selectable, schema, materialized=False):
         self.name = name
         self.selectable = selectable
         self.materialized = materialized
+        self.materialized = schema
+
 
 
 @compiler.compiles(CreateView)
 def compile_create_materialized_view(element, compiler, **kw):
     return 'CREATE {}VIEW {} AS {}'.format(
         'MATERIALIZED ' if element.materialized else '',
-        compiler.dialect.identifier_preparer.quote(element.name),
+        # compiler.dialect.identifier_preparer.quote(element.name),
+        compiler.dialect.identifier_preparer.format_table(
+            element.name, element.schema, use_schema=True),
         compiler.sql_compiler.process(element.selectable, literal_binds=True),
     )
 
@@ -43,6 +47,7 @@ def create_table_from_selectable(
     indexes=None,
     metadata=None,
     aliases=None,
+    schema = None,
     **kwargs
 ):
     if indexes is None:
@@ -60,7 +65,7 @@ def create_table_from_selectable(
         )
         for c in get_columns(selectable)
     ] + indexes
-    table = sa.Table(name, metadata, *args, **kwargs)
+    table = sa.Table(name, metadata, schema=schema, *args, **kwargs)
 
     if not any([c.primary_key for c in get_columns(selectable)]):
         table.append_constraint(
@@ -74,7 +79,8 @@ def create_materialized_view(
     selectable,
     metadata,
     indexes=None,
-    aliases=None
+    aliases=None,
+    schema=None,
 ):
     """ Create a view on a given metadata
 
@@ -87,6 +93,7 @@ def create_materialized_view(
     :param aliases:
         An optional dictionary containing with keys as column names and values
         as column aliases.
+    :param schema: optinal the schema name for the view
 
     Same as for ``create_view`` except that a ``CREATE MATERIALIZED VIEW``
     statement is emitted instead of a ``CREATE VIEW``.
@@ -97,13 +104,15 @@ def create_materialized_view(
         selectable=selectable,
         indexes=indexes,
         metadata=None,
-        aliases=aliases
+        aliases=aliases,
+        schema=schema
+
     )
 
     sa.event.listen(
         metadata,
         'after_create',
-        CreateView(name, selectable, materialized=True)
+        CreateView(name, selectable, schema, materialized=True)
     )
 
     @sa.event.listens_for(metadata, 'after_create')
@@ -123,6 +132,8 @@ def create_view(
     name,
     selectable,
     metadata,
+    schema=None,
+    # indexes=None, Does non-materialized views allow index creation??
     cascade_on_drop=True
 ):
     """ Create a view on a given metadata
@@ -132,6 +143,8 @@ def create_view(
     :param metadata:
         An SQLAlchemy Metadata instance that stores the features of the
         database being described.
+    :param schema: optinal the schema name for the view
+
 
     The process for creating a view is similar to the standard way that a
     table is constructed, except that a selectable is provided instead of
@@ -147,10 +160,11 @@ def create_view(
                 Column('name', String),
                 Column('fullname', String),
                 Column('premium_user', Boolean, default=False),
+                schema=None
             )
 
         premium_members = select([users]).where(users.c.premium_user == True)
-        create_view('premium_users', premium_members, metadata)
+        create_view('premium_users', premium_members, metadata,)
 
         metadata.create_all(engine) # View is created at this point
 
@@ -158,13 +172,15 @@ def create_view(
     table = create_table_from_selectable(
         name=name,
         selectable=selectable,
+        schema=schema,
+        # indexes=indexes,???
         metadata=None
     )
 
-    sa.event.listen(metadata, 'after_create', CreateView(name, selectable))
+    sa.event.listen(metadata, 'after_create', CreateView(name, selectable, schema))
 
     @sa.event.listens_for(metadata, 'after_create')
-    def create_indexes(target, connection, **kw):
+    def create_indexes(target, connection, **kw): ##  Does non-materialized views allow index creation??
         for idx in table.indexes:
             idx.create(connection)
 
@@ -176,21 +192,41 @@ def create_view(
     return table
 
 
-def refresh_materialized_view(session, name, concurrently=False):
+def refresh_materialized_view(session, table, concurrently=False):
     """ Refreshes an already existing materialized view
 
     :param session: An SQLAlchemy Session instance.
-    :param name: The name of the materialized view to refresh.
+    :param table: The view to refresh (table object).
     :param concurrently:
         Optional flag that causes the ``CONCURRENTLY`` parameter
         to be specified when the materialized view is refreshed.
+
+
+    example (flask_sqlalchemy) ORM:
+    User(db.Model):
+    __table__ = create_materialized_view(
+        name = 'user',
+        selectable = db.select(...),
+        schema = 'name'
+        )
+    @classmethod
+    def refresh_view(cls, concurrently=False):
+        refresh_materialized_view(db.session,cls.__table__, concurrently)
+
+    User.refresh_view()
+    >SQL: REFRESH MATERIALIZED VIEW name.user
     """
     # Since session.execute() bypasses autoflush, we must manually flush in
     # order to include newly-created/modified objects in the refresh.
+
+    #  session.bind.engine.dialect.identifier_preparer do no accept str as a param, it schould be the table
+
     session.flush()
     session.execute(
         'REFRESH MATERIALIZED VIEW {}{}'.format(
             'CONCURRENTLY ' if concurrently else '',
-            session.bind.engine.dialect.identifier_preparer.quote(name)
+            # session.bind.engine.dialect.identifier_preparer.quote(name)
+            session.bind.engine.dialect.identifier_preparer.format_table(table, use_schema=True)
         )
     )
+    session.commit() #  needed to persist changes in the materialized view


### PR DESCRIPTION
####  Issue 427: Create a Postgres view in a specific schema #427 
#### schema parameter was added to the create_view functions to define a specific schema. 
#### in the CreateView compiler the compiler.dialect.identifier_preparer.quote was replace by compiler.dialect.identifier_preparer.format_table to prepare a quoted schema name
####  In the refresh_materialized_view() instead of the view name the view/table object is needed as a parameter. The session.commit() was missing therefore changes were not persistent in the DB after refresh. 

