### PR TITLE
Ignore cryptography's Python 3.6 deprecation warning

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -46,3 +46,5 @@ filterwarnings =
     ignore:Exception ignored:pytest.PytestUnraisableExceptionWarning
     ; Ignore DeprecationWarnings caused by pg8000.
     ignore:distutils Version classes are deprecated.:DeprecationWarning
+    ; Ignore cryptography deprecation warnings (Python 3.6).
+    ignore:Python 3.6 is no longer supported:UserWarning


### PR DESCRIPTION
Exactly what it says on the tin.