### PR TITLE
Test against Python 3.10

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.9']
+        python-version: ['3.6', '3.10']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
         tox_env: ['sqlalchemy14']
         include:
           - python-version: '3.6'

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Here you can see the full list of changes between each SQLAlchemy-Utils release.
 - Fixed double-quoted UUID's in sqlalchemy >= 1.4.30 (#581, pull request courtesy of kurtmckee)
 - Fixed create_database() and drop_database() crashing with CockroachDB (#586, pull request courtesy of kurtmckee)
 - Added mixed case support for pg composite (#584, pull request courtesy of bamartin125)
+- Support Python 3.10.
 
 
 0.38.2 (2021-12-29)

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
         'SQLAlchemy>=1.0'
     ],
     extras_require=extras_require,
-    python_requires='~=3.4',
+    python_requires='~=3.6',
     classifiers=[
         'Environment :: Web Environment',
         'Intended Audience :: Developers',
@@ -86,12 +86,11 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36, 37, 38, 39}-sqlalchemy{13, 14}
+    py{36, 37, 38, 39, 310}-sqlalchemy{13, 14}
     lint
 
 [testenv]


### PR DESCRIPTION
Also, update the PyPI trove classifiers in `setup.py` (remove 3.4 and 3.5, and add 3.10).