### PR TITLE
Clarify the phone number dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,6 @@
 [flake8]
+max-line-length = 88
+extend-ignore = E203
 exclude =
     .eggs
     .git

--- a/sqlalchemy_utils/types/phone_number.py
+++ b/sqlalchemy_utils/types/phone_number.py
@@ -16,14 +16,15 @@ except ImportError:
 
 
 class PhoneNumberParseException(NumberParseException, exc.DontWrapMixin):
-    '''
+    """
     Wraps exceptions from phonenumbers with SQLAlchemy's DontWrapMixin
     so we get more meaningful exceptions on validation failure instead of the
     StatementException
 
     Clients can catch this as either a PhoneNumberParseException or
     NumberParseException from the phonenumbers library.
-    '''
+    """
+
     pass
 
 
@@ -77,6 +78,7 @@ class PhoneNumber(BasePhoneNumber):
         should always be True for external callers.
         Can be useful for short codes or toll free
     """
+
     def __init__(self, raw_number, region=None, check_region=True):
         # Bail if phonenumbers is not found.
         if phonenumbers is None:
@@ -86,9 +88,7 @@ class PhoneNumber(BasePhoneNumber):
 
         try:
             self._phone_number = phonenumbers.parse(
-                raw_number,
-                region,
-                _check_region=check_region
+                raw_number, region, _check_region=check_region
             )
         except NumberParseException as e:
             # Wrap exception so SQLAlchemy doesn't swallow it as a
@@ -98,8 +98,7 @@ class PhoneNumber(BasePhoneNumber):
             # it's likely because the API has changed upstream and these
             # bindings need to be updated.
             raise PhoneNumberParseException(
-                getattr(e, 'error_type', -1),
-                six.text_type(e)
+                getattr(e, "error_type", -1), six.text_type(e)
             )
 
         super(PhoneNumber, self).__init__(
@@ -111,20 +110,17 @@ class PhoneNumber(BasePhoneNumber):
             country_code_source=self._phone_number.country_code_source,
             preferred_domestic_carrier_code=(
                 self._phone_number.preferred_domestic_carrier_code
-            )
+            ),
         )
         self.region = region
         self.national = phonenumbers.format_number(
-            self._phone_number,
-            phonenumbers.PhoneNumberFormat.NATIONAL
+            self._phone_number, phonenumbers.PhoneNumberFormat.NATIONAL
         )
         self.international = phonenumbers.format_number(
-            self._phone_number,
-            phonenumbers.PhoneNumberFormat.INTERNATIONAL
+            self._phone_number, phonenumbers.PhoneNumberFormat.INTERNATIONAL
         )
         self.e164 = phonenumbers.format_number(
-            self._phone_number,
-            phonenumbers.PhoneNumberFormat.E164
+            self._phone_number, phonenumbers.PhoneNumberFormat.E164
         )
 
     def __composite_values__(self):
@@ -162,12 +158,13 @@ class PhoneNumberType(ScalarCoercible, types.TypeDecorator):
         user.phone_number.international  # u'+358 40 1234567'
         user.phone_number.national  # u'040 1234567'
     """
-    STORE_FORMAT = 'e164'
+
+    STORE_FORMAT = "e164"
     impl = types.Unicode(20)
     python_type = PhoneNumber
     cache_ok = True
 
-    def __init__(self, region='US', max_length=20, *args, **kwargs):
+    def __init__(self, region="US", max_length=20, *args, **kwargs):
         # Bail if phonenumbers is not found.
         if phonenumbers is None:
             raise ImproperlyConfigured(
@@ -183,8 +180,8 @@ class PhoneNumberType(ScalarCoercible, types.TypeDecorator):
             if not isinstance(value, PhoneNumber):
                 value = PhoneNumber(value, region=self.region)
 
-            if self.STORE_FORMAT == 'e164' and value.extension:
-                return '%s;ext=%s' % (value.e164, value.extension)
+            if self.STORE_FORMAT == "e164" and value.extension:
+                return "%s;ext=%s" % (value.e164, value.extension)
 
             return getattr(value, self.STORE_FORMAT)
 

--- a/sqlalchemy_utils/types/phone_number.py
+++ b/sqlalchemy_utils/types/phone_number.py
@@ -70,9 +70,9 @@ class PhoneNumber(BasePhoneNumber):
 
         user = User(phone_number=PhoneNumber('0401234567', 'FI'))
 
-        user.phone_number.e164  # u'+358401234567'
-        user.phone_number.international  # u'+358 40 1234567'
-        user.phone_number.national  # u'040 1234567'
+        user.phone_number.e164  # '+358401234567'
+        user.phone_number.international  # '+358 40 1234567'
+        user.phone_number.national  # '040 1234567'
         user.country_code  # 'FI'
 
 
@@ -159,9 +159,9 @@ class PhoneNumberType(ScalarCoercible, types.TypeDecorator):
 
         user = User(phone_number='+358401234567')
 
-        user.phone_number.e164  # u'+358401234567'
-        user.phone_number.international  # u'+358 40 1234567'
-        user.phone_number.national  # u'040 1234567'
+        user.phone_number.e164  # '+358401234567'
+        user.phone_number.international  # '+358 40 1234567'
+        user.phone_number.national  # '040 1234567'
     """
 
     STORE_FORMAT = "e164"

--- a/sqlalchemy_utils/types/phone_number.py
+++ b/sqlalchemy_utils/types/phone_number.py
@@ -1,4 +1,3 @@
-import six
 from sqlalchemy import exc, types
 
 from ..exceptions import ImproperlyConfigured
@@ -97,9 +96,7 @@ class PhoneNumber(BasePhoneNumber):
             # Worth noting that if -1 shows up as the error_type
             # it's likely because the API has changed upstream and these
             # bindings need to be updated.
-            raise PhoneNumberParseException(
-                getattr(e, "error_type", -1), six.text_type(e)
-            )
+            raise PhoneNumberParseException(getattr(e, "error_type", -1), str(e))
 
         super(PhoneNumber, self).__init__(
             country_code=self._phone_number.country_code,

--- a/sqlalchemy_utils/types/phone_number.py
+++ b/sqlalchemy_utils/types/phone_number.py
@@ -1,3 +1,11 @@
+"""
+..  note::
+
+    The `phonenumbers`_ package must be installed to use PhoneNumber types.
+
+..  _phonenumbers: https://github.com/daviddrysdale/python-phonenumbers
+"""
+
 from sqlalchemy import exc, types
 
 from ..exceptions import ImproperlyConfigured
@@ -82,7 +90,7 @@ class PhoneNumber(BasePhoneNumber):
         # Bail if phonenumbers is not found.
         if phonenumbers is None:
             raise ImproperlyConfigured(
-                "'phonenumbers' is required to use 'PhoneNumber'"
+                "The 'phonenumbers' package is required to use 'PhoneNumber'"
             )
 
         try:
@@ -165,7 +173,7 @@ class PhoneNumberType(ScalarCoercible, types.TypeDecorator):
         # Bail if phonenumbers is not found.
         if phonenumbers is None:
             raise ImproperlyConfigured(
-                "'phonenumbers' is required to use 'PhoneNumberType'"
+                "The 'phonenumbers' package is required to use 'PhoneNumberType'"
             )
 
         super(PhoneNumberType, self).__init__(*args, **kwargs)

--- a/tests/types/test_phonenumber.py
+++ b/tests/types/test_phonenumber.py
@@ -10,23 +10,24 @@ from sqlalchemy_utils import (  # noqa
 )
 
 VALID_PHONE_NUMBERS = (
-    '040 1234567',
-    '+358 401234567',
-    '09 2501234',
-    '+358 92501234',
-    '0800 939393',
-    '09 4243 0456',
-    '0600 900 500'
+    "040 1234567",
+    "+358 401234567",
+    "09 2501234",
+    "+358 92501234",
+    "0800 939393",
+    "09 4243 0456",
+    "0600 900 500",
 )
 
 
 @pytest.fixture
 def User(Base):
     class User(Base):
-        __tablename__ = 'user'
+        __tablename__ = "user"
         id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
         name = sa.Column(sa.Unicode(255))
         phone_number = sa.Column(PhoneNumberType())
+
     return User
 
 
@@ -37,57 +38,47 @@ def init_models(User):
 
 @pytest.fixture
 def phone_number():
-    return PhoneNumber(
-        '040 1234567',
-        'FI'
-    )
+    return PhoneNumber("040 1234567", "FI")
 
 
 @pytest.fixture
 def user(session, User, phone_number):
     user = User()
-    user.name = u'Someone'
+    user.name = "Someone"
     user.phone_number = phone_number
     session.add(user)
     session.commit()
     return user
 
 
-@pytest.mark.skipif('types.phone_number.phonenumbers is None')
+@pytest.mark.skipif("types.phone_number.phonenumbers is None")
 class TestPhoneNumber:
-    @pytest.mark.parametrize('raw_number', VALID_PHONE_NUMBERS)
+    @pytest.mark.parametrize("raw_number", VALID_PHONE_NUMBERS)
     def test_valid_phone_numbers(self, raw_number):
-        number = PhoneNumber(raw_number, 'FI')
+        number = PhoneNumber(raw_number, "FI")
         assert number.is_valid_number()
 
-    @pytest.mark.parametrize('raw_number', ('abc', '+040 1234567'))
+    @pytest.mark.parametrize("raw_number", ("abc", "+040 1234567"))
     def test_invalid_phone_numbers__constructor_fails(self, raw_number):
         with pytest.raises(PhoneNumberParseException):
-            PhoneNumber(raw_number, 'FI')
+            PhoneNumber(raw_number, "FI")
 
-    @pytest.mark.parametrize('raw_number', ('0111234567', '358'))
+    @pytest.mark.parametrize("raw_number", ("0111234567", "358"))
     def test_invalid_phone_numbers__is_valid_number(self, raw_number):
-        number = PhoneNumber(raw_number, 'FI')
+        number = PhoneNumber(raw_number, "FI")
         assert not number.is_valid_number()
 
-    def test_invalid_phone_numbers_throw_dont_wrap_exception(
-        self,
-        session,
-        User
-    ):
+    def test_invalid_phone_numbers_throw_dont_wrap_exception(self, session, User):
         with pytest.raises(PhoneNumberParseException):
             session.execute(
-                User.__table__.insert().values(
-                    name=u'Someone',
-                    phone_number=u'abc'
-                )
+                User.__table__.insert().values(name="Someone", phone_number="abc")
             )
 
     def test_phone_number_attributes(self):
-        number = PhoneNumber('+358401234567')
-        assert number.e164 == u'+358401234567'
-        assert number.international == u'+358 40 1234567'
-        assert number.national == u'040 1234567'
+        number = PhoneNumber("+358401234567")
+        assert number.e164 == "+358401234567"
+        assert number.international == "+358 40 1234567"
+        assert number.national == "040 1234567"
 
     def test_phone_number_attributes_for_short_code(self):
         """
@@ -96,56 +87,49 @@ class TestPhoneNumber:
         raise exception
         :return:
         """
-        number = PhoneNumber('72404', check_region=False)
-        assert number.e164 == u'+072404'
-        assert number.international == u'72404'
-        assert number.national == u'72404'
+        number = PhoneNumber("72404", check_region=False)
+        assert number.e164 == "+072404"
+        assert number.international == "72404"
+        assert number.national == "72404"
 
     def test_phone_number_str_repr(self):
-        number = PhoneNumber('+358401234567')
+        number = PhoneNumber("+358401234567")
         if six.PY2:
             assert unicode(number) == number.national  # noqa
-            assert str(number) == number.national.encode('utf-8')
+            assert str(number) == number.national.encode("utf-8")
         else:
             assert str(number) == number.national
 
     def test_phone_number_hash(self):
-        number1 = PhoneNumber('+821023456789')
-        number2 = PhoneNumber('+82 10-2345-6789')
+        number1 = PhoneNumber("+821023456789")
+        number2 = PhoneNumber("+82 10-2345-6789")
         assert hash(number1) == hash(number2)
         assert hash(number1) == hash(number1.e164)
         assert {number1} == {number2}
 
 
-@pytest.mark.skipif('types.phone_number.phonenumbers is None')
+@pytest.mark.skipif("types.phone_number.phonenumbers is None")
 class TestPhoneNumberType:
-    def test_query_returns_phone_number_object(
-        self,
-        session,
-        User,
-        user,
-        phone_number
-    ):
+    def test_query_returns_phone_number_object(self, session, User, user, phone_number):
         queried_user = session.query(User).first()
         assert queried_user.phone_number == phone_number
 
     def test_phone_number_is_stored_as_string(self, session, user):
         result = session.execute(
-            'SELECT phone_number FROM "user" WHERE id=:param',
-            {'param': user.id}
+            'SELECT phone_number FROM "user" WHERE id=:param', {"param": user.id}
         )
-        assert result.first()[0] == u'+358401234567'
+        assert result.first()[0] == "+358401234567"
 
     def test_phone_number_with_extension(self, session, User):
-        user = User(phone_number='555-555-5555 Ext. 555')
+        user = User(phone_number="555-555-5555 Ext. 555")
 
         session.add(user)
         session.commit()
         session.refresh(user)
-        assert user.phone_number.extension == '555'
+        assert user.phone_number.extension == "555"
 
     def test_empty_phone_number_is_equiv_to_none(self, session, User):
-        user = User(phone_number='')
+        user = User(phone_number="")
 
         session.add(user)
         session.commit()
@@ -155,24 +139,23 @@ class TestPhoneNumberType:
     def test_uses_phonenumber_class_as_python_type(self):
         assert PhoneNumberType().python_type is PhoneNumber
 
-    @pytest.mark.usefixtures('user')
+    @pytest.mark.usefixtures("user")
     def test_phone_number_is_none(self, session, User):
         phone_number = None
         user = User()
-        user.name = u'Someone'
+        user.name = "Someone"
         user.phone_number = phone_number
         session.add(user)
         session.commit()
         queried_user = session.query(User)[1]
         assert queried_user.phone_number is None
         result = session.execute(
-            'SELECT phone_number FROM "user" WHERE id=:param',
-            {'param': user.id}
+            'SELECT phone_number FROM "user" WHERE id=:param', {"param": user.id}
         )
         assert result.first()[0] is None
 
     def test_scalar_attributes_get_coerced_to_objects(self, User):
-        user = User(phone_number='050111222')
+        user = User(phone_number="050111222")
 
         assert isinstance(user.phone_number, PhoneNumber)
 
@@ -182,38 +165,30 @@ class TestPhoneNumberType:
         session.execute(query)
 
 
-@pytest.mark.skipif('types.phone_number.phonenumbers is None')
+@pytest.mark.skipif("types.phone_number.phonenumbers is None")
 class TestPhoneNumberComposite:
     @pytest.fixture
     def User(self, Base):
         class User(Base):
-            __tablename__ = 'user'
+            __tablename__ = "user"
             id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
             name = sa.Column(sa.String(255))
             _phone_number = sa.Column(sa.String(255))
             country = sa.Column(sa.String(255))
-            phone_number = sa.orm.composite(
-                PhoneNumber,
-                _phone_number,
-                country
-            )
+            phone_number = sa.orm.composite(PhoneNumber, _phone_number, country)
+
         return User
 
     @pytest.fixture
     def user(self, session, User):
         user = User()
-        user.name = u'Someone'
-        user.phone_number = PhoneNumber('+35840111222', 'FI')
+        user.name = "Someone"
+        user.phone_number = PhoneNumber("+35840111222", "FI")
         session.add(user)
         session.commit()
         return user
 
-    def test_query_returns_phone_number_object(
-        self,
-        session,
-        User,
-        user
-    ):
+    def test_query_returns_phone_number_object(self, session, User, user):
         queried_user = session.query(User).first()
-        assert queried_user.phone_number.national == '040 111222'
-        assert queried_user.phone_number.region == 'FI'
+        assert queried_user.phone_number.national == "040 111222"
+        assert queried_user.phone_number.region == "FI"

--- a/tests/types/test_phonenumber.py
+++ b/tests/types/test_phonenumber.py
@@ -1,5 +1,4 @@
 import pytest
-import six
 import sqlalchemy as sa
 
 from sqlalchemy_utils import (  # noqa
@@ -94,11 +93,7 @@ class TestPhoneNumber:
 
     def test_phone_number_str_repr(self):
         number = PhoneNumber("+358401234567")
-        if six.PY2:
-            assert unicode(number) == number.national  # noqa
-            assert str(number) == number.national.encode("utf-8")
-        else:
-            assert str(number) == number.national
+        assert str(number) == number.national
 
     def test_phone_number_hash(self):
         number1 = PhoneNumber("+821023456789")

--- a/tox.ini
+++ b/tox.ini
@@ -38,8 +38,8 @@ commands =
     isort --verbose --check-only .
 skip_install = True
 deps =
-    flake8>=3.7.9
-    isort>=4.3.21
+    flake8
+    isort
 
 [pytest]
 filterwarnings =


### PR DESCRIPTION
This also runs black against the phone number code and tests, removes references to the `six` package in the phone number code and tests, and removes the `u` string prefixes in the phone number docstrings.


Closes #600