### PR TITLE
Show the phone_number module docstring in the docs

### DIFF
--- a/docs/data_types.rst
+++ b/docs/data_types.rst
@@ -127,7 +127,7 @@ PasswordType
 PhoneNumberType
 ---------------
 
-.. module:: sqlalchemy_utils.types.phone_number
+.. automodule:: sqlalchemy_utils.types.phone_number
 
 .. autoclass:: PhoneNumber
 


### PR DESCRIPTION
This change allows the docs to show the `phone_number.py` docstring.

This was the intention of a previous commit -- which includes a note that the phonenumbers package must be installed to use PhoneNumber types -- but now the note will actually be displayed.