### PR TITLE
Remove Python 2 compatibility code

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Here you can see the full list of changes between each SQLAlchemy-Utils release.
 - Fixed create_database() and drop_database() crashing with CockroachDB (#586, pull request courtesy of kurtmckee)
 - Added mixed case support for pg composite (#584, pull request courtesy of bamartin125)
 - Support Python 3.10.
+- Remove the dependency on the six package. (#605)
 
 
 0.38.2 (2021-12-29)

--- a/conftest.py
+++ b/conftest.py
@@ -171,7 +171,7 @@ def Category(Base):
 
         @hybrid_property
         def full_name(self):
-            return u'%s %s' % (self.title, self.name)
+            return '%s %s' % (self.title, self.name)
 
         @full_name.expression
         def full_name(self):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,8 +42,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'SQLAlchemy-Utils'
-copyright = u'2013-2022, Konsta Vesterinen'
+project = 'SQLAlchemy-Utils'
+copyright = '2013-2022, Konsta Vesterinen'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -185,8 +185,8 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'SQLAlchemy-Utils.tex', u'SQLAlchemy-Utils Documentation',
-   u'Konsta Vesterinen', 'manual'),
+  ('index', 'SQLAlchemy-Utils.tex', 'SQLAlchemy-Utils Documentation',
+   'Konsta Vesterinen', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -215,8 +215,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'sqlalchemy-utils', u'SQLAlchemy-Utils Documentation',
-     [u'Konsta Vesterinen'], 1)
+    ('index', 'sqlalchemy-utils', 'SQLAlchemy-Utils Documentation',
+     ['Konsta Vesterinen'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -229,8 +229,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'SQLAlchemy-Utils', u'SQLAlchemy-Utils Documentation',
-   u'Konsta Vesterinen', 'SQLAlchemy-Utils', 'One line description of project.',
+  ('index', 'SQLAlchemy-Utils', 'SQLAlchemy-Utils Documentation',
+   'Konsta Vesterinen', 'SQLAlchemy-Utils', 'One line description of project.',
    'Miscellaneous'),
 ]
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # SQLAlchemy-Utils documentation build configuration file, created by
 # sphinx-quickstart on Tue Feb 19 11:16:09 2013.
 #

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -12,6 +12,7 @@ SQLAlchemy-Utils is currently tested against the following Python platforms.
 - cPython 3.7
 - cPython 3.8
 - cPython 3.9
+- cPython 3.10
 
 
 Installing an official release
@@ -20,7 +21,7 @@ Installing an official release
 You can install the most recent official SQLAlchemy-Utils version using
 pip_::
 
-    pip install sqlalchemy-utils    # Use `pip3` instead of `pip` for Python 3.x
+    pip install sqlalchemy-utils
 
 .. _pip: http://www.pip-installer.org/
 
@@ -35,7 +36,7 @@ copy of the source. You can do that by cloning the git_ repository::
 Then you can install the source distribution using pip::
 
     cd sqlalchemy-utils
-    pip install -e .    # Use `pip3` instead of `pip` for Python 3.x
+    pip install -e .
 
 .. _git: http://git-scm.org/
 

--- a/setup.py
+++ b/setup.py
@@ -74,8 +74,7 @@ setup(
     include_package_data=True,
     platforms='any',
     install_requires=[
-        'six',
-        'SQLAlchemy>=1.0'
+        'SQLAlchemy>=1.0',
     ],
     extras_require=extras_require,
     python_requires='~=3.6',

--- a/sqlalchemy_utils/aggregates.py
+++ b/sqlalchemy_utils/aggregates.py
@@ -434,7 +434,7 @@ def aggregate_expression(expr, class_):
         return expr(class_)
 
 
-class AggregatedValue(object):
+class AggregatedValue:
     def __init__(self, class_, attr, path, expr):
         self.class_ = class_
         self.attr = attr
@@ -499,7 +499,7 @@ class AggregatedValue(object):
                 )
 
 
-class AggregationManager(object):
+class AggregationManager:
     def __init__(self):
         self.reset()
 

--- a/sqlalchemy_utils/aggregates.py
+++ b/sqlalchemy_utils/aggregates.py
@@ -72,9 +72,9 @@ Simple aggregates
         thread_id = sa.Column(sa.Integer, sa.ForeignKey(Thread.id))
 
 
-    thread = Thread(name=u'SQLAlchemy development')
-    thread.comments.append(Comment(u'Going good!'))
-    thread.comments.append(Comment(u'Great new features!'))
+    thread = Thread(name='SQLAlchemy development')
+    thread.comments.append(Comment('Going good!'))
+    thread.comments.append(Comment('Great new features!'))
 
     session.add(thread)
     session.commit()
@@ -138,7 +138,7 @@ Now the net_worth column of Catalog model will be automatically whenever:
 
 
     catalog = Catalog(
-        name=u'My first catalog',
+        name='My first catalog',
         products=[
             product1,
             product2
@@ -252,8 +252,8 @@ scenarios includes things such as:
 
 
 
-        user = User(name=u'John Matrix')
-        user.groups = [Group(name=u'Group A'), Group(name=u'Group B')]
+        user = User(name='John Matrix')
+        user.groups = [Group(name='Group A'), Group(name='Group B')]
 
         session.add(user)
         session.commit()

--- a/sqlalchemy_utils/asserts.py
+++ b/sqlalchemy_utils/asserts.py
@@ -73,13 +73,13 @@ def _repeated_value(type_):
         if isinstance(type_.item_type, sa.Integer):
             return [0]
         elif isinstance(type_.item_type, sa.String):
-            return [u'a']
+            return ['a']
         elif isinstance(type_.item_type, sa.Numeric):
             return [Decimal('0')]
         else:
             raise TypeError('Unknown array item type')
     else:
-        return u'a'
+        return 'a'
 
 
 def _expected_exception(type_):

--- a/sqlalchemy_utils/functions/orm.py
+++ b/sqlalchemy_utils/functions/orm.py
@@ -739,7 +739,7 @@ def has_changes(obj, attrs=None, exclude=None):
 
         has_changes(user, 'name')  # False
 
-        user.name = u'someone'
+        user.name = 'someone'
 
         has_changes(user, 'name')  # True
 
@@ -838,7 +838,7 @@ def identity(obj_or_class):
         from sqlalchemy_utils import identity
 
 
-        user = User(name=u'John Matrix')
+        user = User(name='John Matrix')
         session.add(user)
         identity(user)  # None
         inspect(user).identity  # None
@@ -880,8 +880,8 @@ def naturally_equivalent(obj, obj2):
         from sqlalchemy_utils import naturally_equivalent
 
 
-        user = User(name=u'someone')
-        user2 = User(name=u'someone')
+        user = User(name='someone')
+        user2 = User(name='someone')
 
         user == user2  # False
 

--- a/sqlalchemy_utils/functions/orm.py
+++ b/sqlalchemy_utils/functions/orm.py
@@ -3,7 +3,6 @@ from functools import partial
 from inspect import isclass
 from operator import attrgetter
 
-import six
 import sqlalchemy as sa
 from sqlalchemy.engine.interfaces import Dialect
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -772,7 +771,7 @@ def has_changes(obj, attrs=None, exclude=None):
     :param exclude: Names of the attributes to exclude
     """
     if attrs:
-        if isinstance(attrs, six.string_types):
+        if isinstance(attrs, str):
             return (
                 sa.inspect(obj)
                 .attrs

--- a/sqlalchemy_utils/functions/render.py
+++ b/sqlalchemy_utils/functions/render.py
@@ -1,6 +1,6 @@
 import inspect
+import io
 
-import six
 import sqlalchemy as sa
 
 from .mock import create_mock_engine
@@ -24,7 +24,7 @@ def render_expression(expression, bind, stream=None):
     # Create a stream if not present.
 
     if stream is None:
-        stream = six.moves.cStringIO()
+        stream = io.StringIO()
 
     engine = create_mock_engine(bind, stream)
 
@@ -36,7 +36,7 @@ def render_expression(expression, bind, stream=None):
             frame = frame[0]
             local = dict(frame.f_locals)
             local['engine'] = engine
-            six.exec_(expression, frame.f_globals, local)
+            exec(expression, frame.f_globals, local)
             break
         except Exception:
             pass
@@ -68,7 +68,7 @@ def render_statement(statement, bind=None):
     elif bind is None:
         bind = statement.bind
 
-    stream = six.moves.cStringIO()
+    stream = io.StringIO()
     engine = create_mock_engine(bind.engine, stream=stream)
     engine.execute(statement)
 

--- a/sqlalchemy_utils/generic.py
+++ b/sqlalchemy_utils/generic.py
@@ -1,6 +1,5 @@
 from collections.abc import Iterable
 
-import six
 import sqlalchemy as sa
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import attributes, class_mapper, ColumnProperty
@@ -74,7 +73,7 @@ class GenericAttributeImpl(attributes.ScalarAttributeImpl):
             pk = mapper.identity_key_from_instance(initiator)[1]
 
             # Set the identifier and the discriminator.
-            discriminator = six.text_type(class_.__name__)
+            discriminator = class_.__name__
 
             for index, id in enumerate(self.parent_token.id):
                 dict_[id.key] = pk[index]
@@ -117,7 +116,7 @@ class GenericRelationshipProperty(MapperProperty):
 
     def init(self):
         def convert_strings(column):
-            if isinstance(column, six.string_types):
+            if isinstance(column, str):
                 return self.parent.columns[column]
             return column
 
@@ -144,7 +143,7 @@ class GenericRelationshipProperty(MapperProperty):
             self._parententity = parentmapper
 
         def __eq__(self, other):
-            discriminator = six.text_type(type(other).__name__)
+            discriminator = type(other).__name__
             q = self.property._discriminator_col == discriminator
             other_id = identity(other)
             for index, id in enumerate(self.property._id_cols):
@@ -158,9 +157,9 @@ class GenericRelationshipProperty(MapperProperty):
             mapper = sa.inspect(other)
             # Iterate through the weak sequence in order to get the actual
             # mappers
-            class_names = [six.text_type(other.__name__)]
+            class_names = [other.__name__]
             class_names.extend([
-                six.text_type(submapper.class_.__name__)
+                submapper.class_.__name__
                 for submapper in mapper._inheriting_mappers
             ])
 

--- a/sqlalchemy_utils/i18n.py
+++ b/sqlalchemy_utils/i18n.py
@@ -1,4 +1,3 @@
-import six
 import sqlalchemy as sa
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -59,7 +58,7 @@ class cast_locale_expr(ColumnElement):
 @compiles(cast_locale_expr)
 def compile_cast_locale_expr(element, compiler, **kw):
     locale = cast_locale(element.cls, element.locale, element.attr)
-    if isinstance(locale, six.string_types):
+    if isinstance(locale, str):
         return "'{0}'".format(locale)
     return compiler.process(locale)
 

--- a/sqlalchemy_utils/i18n.py
+++ b/sqlalchemy_utils/i18n.py
@@ -63,7 +63,7 @@ def compile_cast_locale_expr(element, compiler, **kw):
     return compiler.process(locale)
 
 
-class TranslationHybrid(object):
+class TranslationHybrid:
     def __init__(self, current_locale, default_locale, default_value=None):
         if babel is None:
             raise ImproperlyConfigured(

--- a/sqlalchemy_utils/listeners.py
+++ b/sqlalchemy_utils/listeners.py
@@ -76,13 +76,13 @@ def force_auto_coercion(mapper=None):
         document.background_color  # Color object
         session.commit()
 
-    A useful side-effect of this is that additional validation of data will be
+    A useful side effect of this is that additional validation of data will be
     done on the moment it is being assigned to model objects. For example
-    without auto coerction set, an invalid
+    without autocorrection set, an invalid
     :class:`sqlalchemy_utils.types.IPAddressType` (eg. ``10.0.0 255.255``)
     would get through without an exception being raised. The database wouldn't
     notice this (as most databases don't have a native type for an IP address,
-    so they're usually just stored as a string), and the ``ipaddress/ipaddr``
+    so they're usually just stored as a string), and the ``ipaddress``
     package uses a string field as well.
 
     :param mapper: The mapper which the automatic data type coercion should be

--- a/sqlalchemy_utils/models.py
+++ b/sqlalchemy_utils/models.py
@@ -4,7 +4,7 @@ import sqlalchemy as sa
 from sqlalchemy.util.langhelpers import symbol
 
 
-class Timestamp(object):
+class Timestamp:
     """Adds `created` and `updated` columns to a derived declarative model.
 
     The `created` column is handled through a default and the `updated`

--- a/sqlalchemy_utils/observer.py
+++ b/sqlalchemy_utils/observer.py
@@ -185,7 +185,7 @@ from .utils import is_sequence
 Callback = namedtuple('Callback', ['func', 'backref', 'fullpath'])
 
 
-class PropertyObserver(object):
+class PropertyObserver:
     def __init__(self):
         self.listener_args = [
             (

--- a/sqlalchemy_utils/path.py
+++ b/sqlalchemy_utils/path.py
@@ -6,7 +6,7 @@ from .utils import str_coercible
 
 
 @str_coercible
-class Path(object):
+class Path:
     def __init__(self, path, separator='.'):
         if isinstance(path, Path):
             self.path = path.path
@@ -61,7 +61,7 @@ def get_attr(mixed, attr):
 
 
 @str_coercible
-class AttrPath(object):
+class AttrPath:
     def __init__(self, class_, path):
         self.class_ = class_
         self.path = Path(path)

--- a/sqlalchemy_utils/primitives/country.py
+++ b/sqlalchemy_utils/primitives/country.py
@@ -6,7 +6,7 @@ from ..utils import str_coercible
 
 @total_ordering
 @str_coercible
-class Country(object):
+class Country:
     """
     Country class wraps a 2 to 3 letter country code. It provides various
     convenience properties and methods.

--- a/sqlalchemy_utils/primitives/country.py
+++ b/sqlalchemy_utils/primitives/country.py
@@ -1,7 +1,5 @@
 from functools import total_ordering
 
-import six
-
 from .. import i18n
 from ..utils import str_coercible
 
@@ -57,7 +55,7 @@ class Country(object):
     def __init__(self, code_or_country):
         if isinstance(code_or_country, Country):
             self.code = code_or_country.code
-        elif isinstance(code_or_country, six.string_types):
+        elif isinstance(code_or_country, str):
             self.validate(code_or_country)
             self.code = code_or_country
         else:
@@ -87,7 +85,7 @@ class Country(object):
     def __eq__(self, other):
         if isinstance(other, Country):
             return self.code == other.code
-        elif isinstance(other, six.string_types):
+        elif isinstance(other, str):
             return self.code == other
         else:
             return NotImplemented
@@ -101,7 +99,7 @@ class Country(object):
     def __lt__(self, other):
         if isinstance(other, Country):
             return self.code < other.code
-        elif isinstance(other, six.string_types):
+        elif isinstance(other, str):
             return self.code < other
         return NotImplemented
 

--- a/sqlalchemy_utils/primitives/currency.py
+++ b/sqlalchemy_utils/primitives/currency.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-import six
-
 from .. import i18n, ImproperlyConfigured
 from ..utils import str_coercible
 
@@ -60,7 +58,7 @@ class Currency(object):
             )
         if isinstance(code, Currency):
             self.code = code
-        elif isinstance(code, six.string_types):
+        elif isinstance(code, str):
             self.validate(code)
             self.code = code
         else:
@@ -94,7 +92,7 @@ class Currency(object):
     def __eq__(self, other):
         if isinstance(other, Currency):
             return self.code == other.code
-        elif isinstance(other, six.string_types):
+        elif isinstance(other, str):
             return self.code == other
         else:
             return NotImplemented

--- a/sqlalchemy_utils/primitives/currency.py
+++ b/sqlalchemy_utils/primitives/currency.py
@@ -4,7 +4,7 @@ from ..utils import str_coercible
 
 
 @str_coercible
-class Currency(object):
+class Currency:
     """
     Currency class wraps a 3-letter currency code. It provides various
     convenience properties and methods.

--- a/sqlalchemy_utils/primitives/currency.py
+++ b/sqlalchemy_utils/primitives/currency.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from .. import i18n, ImproperlyConfigured
 from ..utils import str_coercible
 

--- a/sqlalchemy_utils/primitives/ltree.py
+++ b/sqlalchemy_utils/primitives/ltree.py
@@ -2,8 +2,6 @@ from __future__ import absolute_import
 
 import re
 
-import six
-
 from ..utils import str_coercible
 
 path_matcher = re.compile(r'^[A-Za-z0-9_]+(\.[A-Za-z0-9_]+)*$')
@@ -99,7 +97,7 @@ class Ltree(object):
     def __init__(self, path_or_ltree):
         if isinstance(path_or_ltree, Ltree):
             self.path = path_or_ltree.path
-        elif isinstance(path_or_ltree, six.string_types):
+        elif isinstance(path_or_ltree, str):
             self.validate(path_or_ltree)
             self.path = path_or_ltree
         else:
@@ -191,7 +189,7 @@ class Ltree(object):
     def __eq__(self, other):
         if isinstance(other, Ltree):
             return self.path == other.path
-        elif isinstance(other, six.string_types):
+        elif isinstance(other, str):
             return self.path == other
         else:
             return NotImplemented

--- a/sqlalchemy_utils/primitives/ltree.py
+++ b/sqlalchemy_utils/primitives/ltree.py
@@ -8,7 +8,7 @@ path_matcher = re.compile(r'^[A-Za-z0-9_]+(\.[A-Za-z0-9_]+)*$')
 
 
 @str_coercible
-class Ltree(object):
+class Ltree:
     """
     Ltree class wraps a valid string label path. It provides various
     convenience properties and methods.

--- a/sqlalchemy_utils/primitives/ltree.py
+++ b/sqlalchemy_utils/primitives/ltree.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import re
 
 from ..utils import str_coercible

--- a/sqlalchemy_utils/primitives/weekday.py
+++ b/sqlalchemy_utils/primitives/weekday.py
@@ -7,7 +7,7 @@ from ..utils import str_coercible
 
 @str_coercible
 @total_ordering
-class WeekDay(object):
+class WeekDay:
     NUM_WEEK_DAYS = 7
 
     def __init__(self, index):

--- a/sqlalchemy_utils/primitives/weekday.py
+++ b/sqlalchemy_utils/primitives/weekday.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from functools import total_ordering
 
 from .. import i18n

--- a/sqlalchemy_utils/primitives/weekdays.py
+++ b/sqlalchemy_utils/primitives/weekdays.py
@@ -3,7 +3,7 @@ from .weekday import WeekDay
 
 
 @str_coercible
-class WeekDays(object):
+class WeekDays:
     def __init__(self, bit_string_or_week_days):
         if isinstance(bit_string_or_week_days, str):
             self._days = set()

--- a/sqlalchemy_utils/primitives/weekdays.py
+++ b/sqlalchemy_utils/primitives/weekdays.py
@@ -49,7 +49,7 @@ class WeekDays(object):
         )
 
     def __unicode__(self):
-        return u', '.join(str(day) for day in self)
+        return ', '.join(str(day) for day in self)
 
     def as_bit_string(self):
         return ''.join(

--- a/sqlalchemy_utils/primitives/weekdays.py
+++ b/sqlalchemy_utils/primitives/weekdays.py
@@ -1,5 +1,3 @@
-import six
-
 from ..utils import str_coercible
 from .weekday import WeekDay
 
@@ -7,7 +5,7 @@ from .weekday import WeekDay
 @str_coercible
 class WeekDays(object):
     def __init__(self, bit_string_or_week_days):
-        if isinstance(bit_string_or_week_days, six.string_types):
+        if isinstance(bit_string_or_week_days, str):
             self._days = set()
 
             if len(bit_string_or_week_days) != WeekDay.NUM_WEEK_DAYS:
@@ -32,7 +30,7 @@ class WeekDays(object):
     def __eq__(self, other):
         if isinstance(other, WeekDays):
             return self._days == other._days
-        elif isinstance(other, six.string_types):
+        elif isinstance(other, str):
             return self.as_bit_string() == other
         else:
             return NotImplemented
@@ -51,10 +49,10 @@ class WeekDays(object):
         )
 
     def __unicode__(self):
-        return u', '.join(six.text_type(day) for day in self)
+        return u', '.join(str(day) for day in self)
 
     def as_bit_string(self):
         return ''.join(
             '1' if WeekDay(index) in self._days else '0'
-            for index in six.moves.xrange(WeekDay.NUM_WEEK_DAYS)
+            for index in range(WeekDay.NUM_WEEK_DAYS)
         )

--- a/sqlalchemy_utils/proxy_dict.py
+++ b/sqlalchemy_utils/proxy_dict.py
@@ -1,7 +1,7 @@
 import sqlalchemy as sa
 
 
-class ProxyDict(object):
+class ProxyDict:
     def __init__(self, parent, collection_name, mapping_attr):
         self.parent = parent
         self.collection_name = collection_name

--- a/sqlalchemy_utils/query_chain.py
+++ b/sqlalchemy_utils/query_chain.py
@@ -108,7 +108,7 @@ with :meth:`~QueryChain.count`::
 from copy import copy
 
 
-class QueryChain(object):
+class QueryChain:
     """
     QueryChain can be used as a wrapper for sequence of queries.
 

--- a/sqlalchemy_utils/types/arrow.py
+++ b/sqlalchemy_utils/types/arrow.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from ..exceptions import ImproperlyConfigured
 from .enriched_datetime import ArrowDateTime
 from .enriched_datetime.enriched_datetime_type import EnrichedDateTimeType

--- a/sqlalchemy_utils/types/choice.py
+++ b/sqlalchemy_utils/types/choice.py
@@ -36,10 +36,7 @@ class ChoiceType(ScalarCoercible, types.TypeDecorator):
     """
     ChoiceType offers way of having fixed set of choices for given column. It
     could work with a list of tuple (a collection of key-value pairs), or
-    integrate with :mod:`enum` in the standard library of Python 3.4+ (the
-    enum34_ backported package on PyPI is compatible too for ``< 3.4``).
-
-    .. _enum34: https://pypi.python.org/pypi/enum34
+    integrate with :mod:`enum` in the standard library of Python 3.
 
     Columns with ChoiceTypes are automatically coerced to Choice objects while
     a list of tuple been passed to the constructor. If a subclass of

--- a/sqlalchemy_utils/types/choice.py
+++ b/sqlalchemy_utils/types/choice.py
@@ -50,8 +50,8 @@ class ChoiceType(ScalarCoercible, types.TypeDecorator):
 
         class User(Base):
             TYPES = [
-                (u'admin', u'Admin'),
-                (u'regular-user', u'Regular user')
+                ('admin', 'Admin'),
+                ('regular-user', 'Regular user')
             ]
 
             __tablename__ = 'user'
@@ -60,8 +60,8 @@ class ChoiceType(ScalarCoercible, types.TypeDecorator):
             type = sa.Column(ChoiceType(TYPES))
 
 
-        user = User(type=u'admin')
-        user.type  # Choice(code='admin', value=u'Admin')
+        user = User(type='admin')
+        user.type  # Choice(code='admin', value='Admin')
 
     Or::
 
@@ -94,8 +94,8 @@ class ChoiceType(ScalarCoercible, types.TypeDecorator):
 
         class User(Base):
             TYPES = [
-                (u'admin', _(u'Admin')),
-                (u'regular-user', _(u'Regular user'))
+                ('admin', _('Admin')),
+                ('regular-user', _('Regular user'))
             ]
 
             __tablename__ = 'user'
@@ -104,10 +104,10 @@ class ChoiceType(ScalarCoercible, types.TypeDecorator):
             type = sa.Column(ChoiceType(TYPES))
 
 
-        user = User(type=u'admin')
-        user.type  # Choice(code='admin', value=u'Admin')
+        user = User(type='admin')
+        user.type  # Choice(code='admin', value='Admin')
 
-        print user.type  # u'Admin'
+        print user.type  # 'Admin'
 
     Or::
 
@@ -120,8 +120,8 @@ class ChoiceType(ScalarCoercible, types.TypeDecorator):
             regular = 2
 
 
-        UserType.admin.label = _(u'Admin')
-        UserType.regular.label = _(u'Regular user')
+        UserType.admin.label = _('Admin')
+        UserType.regular.label = _('Regular user')
 
 
         class User(Base):
@@ -134,7 +134,7 @@ class ChoiceType(ScalarCoercible, types.TypeDecorator):
         user = User(type=UserType.admin)
         user.type  # <UserType.admin: 1>
 
-        print user.type.label  # u'Admin'
+        print user.type.label  # 'Admin'
     """
 
     impl = types.Unicode(255)

--- a/sqlalchemy_utils/types/choice.py
+++ b/sqlalchemy_utils/types/choice.py
@@ -6,7 +6,7 @@ from ..exceptions import ImproperlyConfigured
 from .scalar_coercible import ScalarCoercible
 
 
-class Choice(object):
+class Choice:
     def __init__(self, code, value):
         self.code = code
         self.value = value
@@ -170,7 +170,7 @@ class ChoiceType(ScalarCoercible, types.TypeDecorator):
         return self.type_impl.process_result_value(value, dialect)
 
 
-class ChoiceTypeImpl(object):
+class ChoiceTypeImpl:
     """The implementation for the ``Choice`` usage."""
 
     def __init__(self, choices):
@@ -198,7 +198,7 @@ class ChoiceTypeImpl(object):
         return value
 
 
-class EnumTypeImpl(object):
+class EnumTypeImpl:
     """The implementation for the ``Enum`` usage."""
 
     def __init__(self, enum_class):

--- a/sqlalchemy_utils/types/color.py
+++ b/sqlalchemy_utils/types/color.py
@@ -1,4 +1,3 @@
-import six
 from sqlalchemy import types
 
 from ..exceptions import ImproperlyConfigured
@@ -66,7 +65,7 @@ class ColorType(ScalarCoercible, types.TypeDecorator):
 
     def process_bind_param(self, value, dialect):
         if value and isinstance(value, colour.Color):
-            return six.text_type(getattr(value, self.STORE_FORMAT))
+            return str(getattr(value, self.STORE_FORMAT))
         return value
 
     def process_result_value(self, value, dialect):

--- a/sqlalchemy_utils/types/country.py
+++ b/sqlalchemy_utils/types/country.py
@@ -1,4 +1,3 @@
-import six
 from sqlalchemy import types
 
 from ..primitives import Country
@@ -52,7 +51,7 @@ class CountryType(ScalarCoercible, types.TypeDecorator):
         if isinstance(value, Country):
             return value.code
 
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             return value
 
     def process_result_value(self, value, dialect):

--- a/sqlalchemy_utils/types/currency.py
+++ b/sqlalchemy_utils/types/currency.py
@@ -1,4 +1,3 @@
-import six
 from sqlalchemy import types
 
 from .. import i18n, ImproperlyConfigured
@@ -62,7 +61,7 @@ class CurrencyType(ScalarCoercible, types.TypeDecorator):
     def process_bind_param(self, value, dialect):
         if isinstance(value, Currency):
             return value.code
-        elif isinstance(value, six.string_types):
+        elif isinstance(value, str):
             return value
 
     def process_result_value(self, value, dialect):

--- a/sqlalchemy_utils/types/encrypted/encrypted_type.py
+++ b/sqlalchemy_utils/types/encrypted/encrypted_type.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import base64
 import datetime
 import json

--- a/sqlalchemy_utils/types/encrypted/encrypted_type.py
+++ b/sqlalchemy_utils/types/encrypted/encrypted_type.py
@@ -302,7 +302,7 @@ class StringEncryptedType(TypeDecorator, ScalarCoercible):
         session = Session()
 
         # example
-        user_name = u'secret_user'
+        user_name = 'secret_user'
         test_token = 'atesttoken'
         active = True
         num_of_accounts = 2

--- a/sqlalchemy_utils/types/encrypted/encrypted_type.py
+++ b/sqlalchemy_utils/types/encrypted/encrypted_type.py
@@ -477,7 +477,7 @@ class EncryptedType(StringEncryptedType):
         return value
 
 
-class DatetimeHandler(object):
+class DatetimeHandler:
     """
     DatetimeHandler is responsible for parsing strings and
     returning the appropriate date, datetime or time objects.

--- a/sqlalchemy_utils/types/encrypted/encrypted_type.py
+++ b/sqlalchemy_utils/types/encrypted/encrypted_type.py
@@ -5,7 +5,6 @@ import json
 import os
 import warnings
 
-import six
 from sqlalchemy.types import LargeBinary, String, TypeDecorator
 
 from sqlalchemy_utils.exceptions import ImproperlyConfigured
@@ -48,7 +47,7 @@ class EncryptionDecryptionBaseEngine:
     """
 
     def _update_key(self, key):
-        if isinstance(key, six.string_types):
+        if isinstance(key, str):
             key = key.encode()
         digest = hashes.Hash(hashes.SHA256(), backend=default_backend())
         digest.update(key)
@@ -90,7 +89,7 @@ class AesEngine(EncryptionDecryptionBaseEngine):
 
     def _set_padding_mechanism(self, padding_mechanism=None):
         """Set the padding mechanism."""
-        if isinstance(padding_mechanism, six.string_types):
+        if isinstance(padding_mechanism, str):
             if padding_mechanism not in PADDING_MECHANISM.keys():
                 raise ImproperlyConfigured(
                     "There is not padding mechanism with name {}".format(
@@ -105,9 +104,9 @@ class AesEngine(EncryptionDecryptionBaseEngine):
         self.padding_engine = padding_class(self.BLOCK_SIZE)
 
     def encrypt(self, value):
-        if not isinstance(value, six.string_types):
+        if not isinstance(value, str):
             value = repr(value)
-        if isinstance(value, six.text_type):
+        if isinstance(value, str):
             value = str(value)
         value = value.encode()
         value = self.padding_engine.pad(value)
@@ -117,13 +116,13 @@ class AesEngine(EncryptionDecryptionBaseEngine):
         return encrypted.decode('utf-8')
 
     def decrypt(self, value):
-        if isinstance(value, six.text_type):
+        if isinstance(value, str):
             value = str(value)
         decryptor = self.cipher.decryptor()
         decrypted = base64.b64decode(value)
         decrypted = decryptor.update(decrypted) + decryptor.finalize()
         decrypted = self.padding_engine.unpad(decrypted)
-        if not isinstance(decrypted, six.string_types):
+        if not isinstance(decrypted, str):
             try:
                 decrypted = decrypted.decode('utf-8')
             except UnicodeDecodeError:
@@ -153,9 +152,9 @@ class AesGcmEngine(EncryptionDecryptionBaseEngine):
         self.secret_key = parent_class_key
 
     def encrypt(self, value):
-        if not isinstance(value, six.string_types):
+        if not isinstance(value, str):
             value = repr(value)
-        if isinstance(value, six.text_type):
+        if isinstance(value, str):
             value = str(value)
         value = value.encode()
         iv = os.urandom(self.IV_BYTES_NEEDED)
@@ -171,7 +170,7 @@ class AesGcmEngine(EncryptionDecryptionBaseEngine):
         return encrypted.decode('utf-8')
 
     def decrypt(self, value):
-        if isinstance(value, six.text_type):
+        if isinstance(value, str):
             value = str(value)
         decrypted = base64.b64decode(value)
         if len(decrypted) < self.IV_BYTES_NEEDED + self.TAG_SIZE_BYTES:
@@ -190,7 +189,7 @@ class AesGcmEngine(EncryptionDecryptionBaseEngine):
             decrypted = decryptor.update(decrypted) + decryptor.finalize()
         except InvalidTag:
             raise InvalidCiphertextError()
-        if not isinstance(decrypted, six.string_types):
+        if not isinstance(decrypted, str):
             try:
                 decrypted = decrypted.decode('utf-8')
             except UnicodeDecodeError:
@@ -206,19 +205,19 @@ class FernetEngine(EncryptionDecryptionBaseEngine):
         self.fernet = Fernet(self.secret_key)
 
     def encrypt(self, value):
-        if not isinstance(value, six.string_types):
+        if not isinstance(value, str):
             value = repr(value)
-        if isinstance(value, six.text_type):
+        if isinstance(value, str):
             value = str(value)
         value = value.encode()
         encrypted = self.fernet.encrypt(value)
         return encrypted.decode('utf-8')
 
     def decrypt(self, value):
-        if isinstance(value, six.text_type):
+        if isinstance(value, str):
             value = str(value)
         decrypted = self.fernet.decrypt(value.encode())
-        if not isinstance(decrypted, six.string_types):
+        if not isinstance(decrypted, str):
             decrypted = decrypted.decode('utf-8')
         return decrypted
 
@@ -411,7 +410,7 @@ class StringEncryptedType(TypeDecorator, ScalarCoercible):
                     value = value.isoformat()
 
                 elif issubclass(type_, JSONType):
-                    value = six.text_type(json.dumps(value))
+                    value = json.dumps(value)
 
             return self.engine.encrypt(value)
 

--- a/sqlalchemy_utils/types/encrypted/padding.py
+++ b/sqlalchemy_utils/types/encrypted/padding.py
@@ -2,7 +2,7 @@ class InvalidPaddingError(Exception):
     pass
 
 
-class Padding(object):
+class Padding:
     """Base class for padding and unpadding."""
 
     def __init__(self, block_size):

--- a/sqlalchemy_utils/types/encrypted/padding.py
+++ b/sqlalchemy_utils/types/encrypted/padding.py
@@ -1,6 +1,3 @@
-import six
-
-
 class InvalidPaddingError(Exception):
     pass
 
@@ -22,10 +19,10 @@ class PKCS5Padding(Padding):
     """Provide PKCS5 padding and unpadding."""
 
     def pad(self, value):
-        if not isinstance(value, six.binary_type):
+        if not isinstance(value, bytes):
             value = value.encode()
         padding_length = (self.block_size - len(value) % self.block_size)
-        padding_sequence = padding_length * six.b(chr(padding_length))
+        padding_sequence = padding_length * bytes((padding_length,))
         value_with_padding = value + padding_sequence
 
         return value_with_padding
@@ -39,15 +36,15 @@ class PKCS5Padding(Padding):
         if len(value) % self.block_size != 0:
             # PKCS5 padded output will be a multiple of the block size
             raise InvalidPaddingError()
-        if isinstance(value, six.binary_type):
+        if isinstance(value, bytes):
             padding_length = value[-1]
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             padding_length = ord(value[-1])
         if padding_length == 0 or padding_length > self.block_size:
             raise InvalidPaddingError()
 
         def convert_byte_or_char_to_number(x):
-            return ord(x) if isinstance(x, six.string_types) else x
+            return ord(x) if isinstance(x, str) else x
         if any([padding_length != convert_byte_or_char_to_number(x)
                for x in value[-padding_length:]]):
             raise InvalidPaddingError()
@@ -68,20 +65,20 @@ class OneAndZeroesPadding(Padding):
     BYTE_00 = 0x00
 
     def pad(self, value):
-        if not isinstance(value, six.binary_type):
+        if not isinstance(value, bytes):
             value = value.encode()
         padding_length = (self.block_size - len(value) % self.block_size)
-        one_part_bytes = six.b(chr(self.BYTE_80))
-        zeroes_part_bytes = (padding_length - 1) * six.b(chr(self.BYTE_00))
+        one_part_bytes = bytes((self.BYTE_80,))
+        zeroes_part_bytes = (padding_length - 1) * bytes((self.BYTE_00,))
         padding_sequence = one_part_bytes + zeroes_part_bytes
         value_with_padding = value + padding_sequence
 
         return value_with_padding
 
     def unpad(self, value):
-        value_without_padding = value.rstrip(six.b(chr(self.BYTE_00)))
+        value_without_padding = value.rstrip(bytes((self.BYTE_00,)))
         value_without_padding = value_without_padding.rstrip(
-            six.b(chr(self.BYTE_80)))
+            bytes((self.BYTE_80,)))
 
         return value_without_padding
 
@@ -97,20 +94,20 @@ class ZeroesPadding(Padding):
     BYTE_00 = 0x00
 
     def pad(self, value):
-        if not isinstance(value, six.binary_type):
+        if not isinstance(value, bytes):
             value = value.encode()
         padding_length = (self.block_size - len(value) % self.block_size)
-        zeroes_part_bytes = (padding_length - 1) * six.b(chr(self.BYTE_00))
-        last_part_bytes = six.b(chr(padding_length))
+        zeroes_part_bytes = (padding_length - 1) * bytes((self.BYTE_00,))
+        last_part_bytes = bytes((padding_length,))
         padding_sequence = zeroes_part_bytes + last_part_bytes
         value_with_padding = value + padding_sequence
 
         return value_with_padding
 
     def unpad(self, value):
-        if isinstance(value, six.binary_type):
+        if isinstance(value, bytes):
             padding_length = value[-1]
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             padding_length = ord(value[-1])
         value_without_padding = value[0:-padding_length]
 
@@ -123,7 +120,7 @@ class NaivePadding(Padding):
     The class is provided only for backwards compatibility.
     """
 
-    CHARACTER = six.b('*')
+    CHARACTER = b'*'
 
     def pad(self, value):
         num_of_bytes = (self.block_size - len(value) % self.block_size)

--- a/sqlalchemy_utils/types/enriched_datetime/arrow_datetime.py
+++ b/sqlalchemy_utils/types/enriched_datetime/arrow_datetime.py
@@ -10,7 +10,7 @@ except ImportError:
     pass
 
 
-class ArrowDateTime(object):
+class ArrowDateTime:
     def __init__(self):
         if not arrow:
             raise ImproperlyConfigured(

--- a/sqlalchemy_utils/types/enriched_datetime/arrow_datetime.py
+++ b/sqlalchemy_utils/types/enriched_datetime/arrow_datetime.py
@@ -1,8 +1,6 @@
 from collections.abc import Iterable
 from datetime import datetime
 
-import six
-
 from ...exceptions import ImproperlyConfigured
 
 arrow = None
@@ -20,7 +18,7 @@ class ArrowDateTime(object):
             )
 
     def _coerce(self, impl, value):
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             value = arrow.get(value)
         elif isinstance(value, Iterable):
             value = arrow.get(*value)

--- a/sqlalchemy_utils/types/enriched_datetime/pendulum_datetime.py
+++ b/sqlalchemy_utils/types/enriched_datetime/pendulum_datetime.py
@@ -9,7 +9,7 @@ except ImportError:
     pass
 
 
-class PendulumDateTime(object):
+class PendulumDateTime:
     def __init__(self):
         if not pendulum:
             raise ImproperlyConfigured(

--- a/sqlalchemy_utils/types/enriched_datetime/pendulum_datetime.py
+++ b/sqlalchemy_utils/types/enriched_datetime/pendulum_datetime.py
@@ -1,7 +1,5 @@
 from datetime import datetime
 
-import six
-
 from ...exceptions import ImproperlyConfigured
 
 pendulum = None
@@ -24,7 +22,7 @@ class PendulumDateTime(object):
                 pass
             elif isinstance(value, (int, float)):
                 value = pendulum.from_timestamp(value)
-            elif isinstance(value, six.string_types) and value.isdigit():
+            elif isinstance(value, str) and value.isdigit():
                 value = pendulum.from_timestamp(int(value))
             elif isinstance(value, datetime):
                 value = pendulum.datetime(

--- a/sqlalchemy_utils/types/ip_address.py
+++ b/sqlalchemy_utils/types/ip_address.py
@@ -1,6 +1,5 @@
 from ipaddress import ip_address
 
-import six
 from sqlalchemy import types
 
 from ..exceptions import ImproperlyConfigured
@@ -53,7 +52,7 @@ class IPAddressType(ScalarCoercible, types.TypeDecorator):
         self.impl = types.Unicode(max_length)
 
     def process_bind_param(self, value, dialect):
-        return six.text_type(value) if value else None
+        return str(value) if value else None
 
     def process_result_value(self, value, dialect):
         return ip_address(value) if value else None

--- a/sqlalchemy_utils/types/ip_address.py
+++ b/sqlalchemy_utils/types/ip_address.py
@@ -2,7 +2,6 @@ from ipaddress import ip_address
 
 from sqlalchemy import types
 
-from ..exceptions import ImproperlyConfigured
 from .scalar_coercible import ScalarCoercible
 
 
@@ -10,12 +9,6 @@ class IPAddressType(ScalarCoercible, types.TypeDecorator):
     """
     Changes IPAddress objects to a string representation on the way in and
     changes them back to IPAddress objects on the way out.
-
-    IPAddressType uses ipaddress package on Python >= 3 and ipaddr_ package on
-    Python 2. In order to use IPAddressType with python you need to install
-    ipaddr_ first.
-
-    .. _ipaddr: https://pypi.python.org/pypi/ipaddr
 
     ::
 
@@ -42,12 +35,6 @@ class IPAddressType(ScalarCoercible, types.TypeDecorator):
     cache_ok = True
 
     def __init__(self, max_length=50, *args, **kwargs):
-        if not ip_address:
-            raise ImproperlyConfigured(
-                "'ipaddr' package is required to use 'IPAddressType' "
-                "in python 2"
-            )
-
         super(IPAddressType, self).__init__(*args, **kwargs)
         self.impl = types.Unicode(max_length)
 

--- a/sqlalchemy_utils/types/json.py
+++ b/sqlalchemy_utils/types/json.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import json
 
 import sqlalchemy as sa

--- a/sqlalchemy_utils/types/json.py
+++ b/sqlalchemy_utils/types/json.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 import json
 
-import six
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql.base import ischema_names
 
@@ -69,7 +68,7 @@ class JSONType(sa.types.TypeDecorator):
         if dialect.name == 'postgresql' and has_postgres_json:
             return value
         if value is not None:
-            value = six.text_type(json.dumps(value))
+            value = json.dumps(value)
         return value
 
     def process_result_value(self, value, dialect):

--- a/sqlalchemy_utils/types/locale.py
+++ b/sqlalchemy_utils/types/locale.py
@@ -1,4 +1,3 @@
-import six
 from sqlalchemy import types
 
 from ..exceptions import ImproperlyConfigured
@@ -62,9 +61,9 @@ class LocaleType(ScalarCoercible, types.TypeDecorator):
 
     def process_bind_param(self, value, dialect):
         if isinstance(value, babel.Locale):
-            return six.text_type(value)
+            return str(value)
 
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             return value
 
     def process_result_value(self, value, dialect):

--- a/sqlalchemy_utils/types/ltree.py
+++ b/sqlalchemy_utils/types/ltree.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from sqlalchemy import types
 from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.dialects.postgresql.base import ischema_names, PGTypeCompiler

--- a/sqlalchemy_utils/types/password.py
+++ b/sqlalchemy_utils/types/password.py
@@ -1,6 +1,5 @@
 import weakref
 
-import six
 from sqlalchemy import types
 from sqlalchemy.dialects import oracle, postgresql, sqlite
 from sqlalchemy.ext.mutable import Mutable
@@ -23,7 +22,7 @@ class Password(Mutable, object):
         if isinstance(value, Password):
             return value
 
-        if isinstance(value, (six.string_types, six.binary_type)):
+        if isinstance(value, (str, bytes)):
             return cls(value, secret=True)
 
         super(Password, cls).coerce(key, value)
@@ -36,7 +35,7 @@ class Password(Mutable, object):
         self.secret = value if secret else None
 
         # The hash should be bytes.
-        if isinstance(self.hash, six.text_type):
+        if isinstance(self.hash, str):
             self.hash = self.hash.encode('utf8')
 
         # Save weakref of the password context (if we have one)
@@ -56,7 +55,7 @@ class Password(Mutable, object):
             # Compare 2 hashes again as we don't know how to validate.
             return value == self
 
-        if isinstance(value, (six.string_types, six.binary_type)):
+        if isinstance(value, (str, bytes)):
             valid, new = self.context.verify_and_update(value, self.hash)
             if valid and new:
                 # New hash was calculated due to various reasons; stored one
@@ -64,7 +63,7 @@ class Password(Mutable, object):
                 self.hash = new
 
                 # The hash should be bytes.
-                if isinstance(self.hash, six.string_types):
+                if isinstance(self.hash, str):
                     self.hash = self.hash.encode('utf8')
                     self.changed()
 
@@ -220,7 +219,7 @@ class PasswordType(ScalarCoercible, types.TypeDecorator):
             # Value has already been hashed.
             return value.hash
 
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             # Assume value has not been hashed.
             return self._hash(value).encode('utf8')
 

--- a/sqlalchemy_utils/types/pg_composite.py
+++ b/sqlalchemy_utils/types/pg_composite.py
@@ -112,7 +112,6 @@ http://schinckel.net/2014/09/24/using-postgres-composite-types-in-django/
 """
 from collections import namedtuple
 
-import six
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql.psycopg2 import PGDialect_psycopg2
 from sqlalchemy.ext.compiler import compiles
@@ -295,8 +294,6 @@ def register_psycopg2_composite(dbapi_connection, composite):
                 value.prepare(dbapi_connection)
         values = [
             value.getquoted().decode(dbapi_connection.encoding)
-            if six.PY3
-            else value.getquoted()
             for value in adapted
         ]
         return AsIs(

--- a/sqlalchemy_utils/types/range.py
+++ b/sqlalchemy_utils/types/range.py
@@ -137,7 +137,6 @@ than 500.
 from collections.abc import Iterable
 from datetime import timedelta
 
-import six
 import sqlalchemy as sa
 from sqlalchemy import types
 from sqlalchemy.dialects.postgresql import (
@@ -173,7 +172,8 @@ class RangeComparator(types.TypeEngine.Comparator):
             self.type.interval_class.type,
             tuple,
             list,
-        ) + six.string_types
+            str,
+        )
 
         if isinstance(other, coerced_types):
             return self.type.interval_class(other)
@@ -182,7 +182,7 @@ class RangeComparator(types.TypeEngine.Comparator):
     def in_(self, other):
         if (
             isinstance(other, Iterable) and
-            not isinstance(other, six.string_types)
+            not isinstance(other, str)
         ):
             other = map(self.coerce_arg, other)
         return super(RangeComparator, self).in_(other)
@@ -190,7 +190,7 @@ class RangeComparator(types.TypeEngine.Comparator):
     def notin_(self, other):
         if (
             isinstance(other, Iterable) and
-            not isinstance(other, six.string_types)
+            not isinstance(other, str)
         ):
             other = map(self.coerce_arg, other)
         return super(RangeComparator, self).notin_(other)
@@ -287,7 +287,7 @@ class RangeType(ScalarCoercible, types.TypeDecorator):
         return value
 
     def process_result_value(self, value, dialect):
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             factory_func = self.interval_class.from_string
         else:
             factory_func = self.interval_class

--- a/sqlalchemy_utils/types/range.py
+++ b/sqlalchemy_utils/types/range.py
@@ -328,7 +328,7 @@ class IntRangeType(RangeType):
             estimated_number_of_persons = sa.Column(IntRangeType)
 
 
-        party = Event(name=u'party')
+        party = Event(name='party')
 
         # we estimate the party to contain minium of 10 persons and at max
         # 100 persons
@@ -342,7 +342,7 @@ class IntRangeType(RangeType):
     support many arithmetic operators::
 
 
-        meeting = Event(name=u'meeting')
+        meeting = Event(name='meeting')
 
         meeting.estimated_number_of_persons = [20, 40]
 
@@ -381,7 +381,7 @@ class Int8RangeType(RangeType):
             estimated_number_of_persons = sa.Column(Int8RangeType)
 
 
-        party = Event(name=u'party')
+        party = Event(name='party')
 
         # we estimate the party to contain minium of 10 persons and at max
         # 100 persons
@@ -395,7 +395,7 @@ class Int8RangeType(RangeType):
     support many arithmetic operators::
 
 
-        meeting = Event(name=u'meeting')
+        meeting = Event(name='meeting')
 
         meeting.estimated_number_of_persons = [20, 40]
 

--- a/sqlalchemy_utils/types/scalar_list.py
+++ b/sqlalchemy_utils/types/scalar_list.py
@@ -1,4 +1,3 @@
-import six
 import sqlalchemy as sa
 from sqlalchemy import types
 
@@ -69,15 +68,15 @@ class ScalarListType(types.TypeDecorator):
 
     cache_ok = True
 
-    def __init__(self, coerce_func=six.text_type, separator=u','):
-        self.separator = six.text_type(separator)
+    def __init__(self, coerce_func=str, separator=u','):
+        self.separator = str(separator)
         self.coerce_func = coerce_func
 
     def process_bind_param(self, value, dialect):
         # Convert list of values to unicode separator-separated list
         # Example: [1, 2, 3, 4] -> u'1, 2, 3, 4'
         if value is not None:
-            if any(self.separator in six.text_type(item) for item in value):
+            if any(self.separator in str(item) for item in value):
                 raise ScalarListException(
                     "List values can't contain string '%s' (its being used as "
                     "separator. If you wish for scalar list values to contain "
@@ -85,7 +84,7 @@ class ScalarListType(types.TypeDecorator):
                     % self.separator
                 )
             return self.separator.join(
-                map(six.text_type, value)
+                map(str, value)
             )
 
     def process_result_value(self, value, dialect):

--- a/sqlalchemy_utils/types/scalar_list.py
+++ b/sqlalchemy_utils/types/scalar_list.py
@@ -26,7 +26,7 @@ class ScalarListType(types.TypeDecorator):
 
 
         user = User()
-        user.hobbies = [u'football', u'ice_hockey']
+        user.hobbies = ['football', 'ice_hockey']
         session.commit()
 
 
@@ -68,13 +68,13 @@ class ScalarListType(types.TypeDecorator):
 
     cache_ok = True
 
-    def __init__(self, coerce_func=str, separator=u','):
+    def __init__(self, coerce_func=str, separator=','):
         self.separator = str(separator)
         self.coerce_func = coerce_func
 
     def process_bind_param(self, value, dialect):
         # Convert list of values to unicode separator-separated list
-        # Example: [1, 2, 3, 4] -> u'1, 2, 3, 4'
+        # Example: [1, 2, 3, 4] -> '1, 2, 3, 4'
         if value is not None:
             if any(self.separator in str(item) for item in value):
                 raise ScalarListException(
@@ -89,7 +89,7 @@ class ScalarListType(types.TypeDecorator):
 
     def process_result_value(self, value, dialect):
         if value is not None:
-            if value == u'':
+            if value == '':
                 return []
             # coerce each value
             return list(map(

--- a/sqlalchemy_utils/types/timezone.py
+++ b/sqlalchemy_utils/types/timezone.py
@@ -1,4 +1,3 @@
-import six
 from sqlalchemy import types
 
 from ..exceptions import ImproperlyConfigured
@@ -42,7 +41,7 @@ class TimezoneType(ScalarCoercible, types.TypeDecorator):
 
                 self.python_type = tzfile
                 self._to = get_zonefile_instance().zones.get
-                self._from = lambda x: six.text_type(x._filename)
+                self._from = lambda x: str(x._filename)
 
             except ImportError:
                 raise ImproperlyConfigured(
@@ -57,7 +56,7 @@ class TimezoneType(ScalarCoercible, types.TypeDecorator):
 
                 self.python_type = BaseTzInfo
                 self._to = timezone
-                self._from = six.text_type
+                self._from = str
 
             except ImportError:
                 raise ImproperlyConfigured(
@@ -80,7 +79,7 @@ class TimezoneType(ScalarCoercible, types.TypeDecorator):
 
             self.python_type = zoneinfo.ZoneInfo
             self._to = zoneinfo.ZoneInfo
-            self._from = six.text_type
+            self._from = str
 
         else:
             raise ImproperlyConfigured(

--- a/sqlalchemy_utils/types/url.py
+++ b/sqlalchemy_utils/types/url.py
@@ -28,7 +28,7 @@ class URLType(ScalarCoercible, types.TypeDecorator):
             website = sa.Column(URLType)
 
 
-        user = User(website=u'www.example.com')
+        user = User(website='www.example.com')
 
         # website is coerced to furl object, hence all nice furl operations
         # come available

--- a/sqlalchemy_utils/types/url.py
+++ b/sqlalchemy_utils/types/url.py
@@ -1,4 +1,3 @@
-import six
 from sqlalchemy import types
 
 from .scalar_coercible import ScalarCoercible
@@ -44,9 +43,9 @@ class URLType(ScalarCoercible, types.TypeDecorator):
 
     def process_bind_param(self, value, dialect):
         if furl is not None and isinstance(value, furl):
-            return six.text_type(value)
+            return str(value)
 
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             return value
 
     def process_result_value(self, value, dialect):

--- a/sqlalchemy_utils/types/uuid.py
+++ b/sqlalchemy_utils/types/uuid.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import uuid
 
 from sqlalchemy import __version__, types, util

--- a/sqlalchemy_utils/types/weekdays.py
+++ b/sqlalchemy_utils/types/weekdays.py
@@ -1,4 +1,3 @@
-import six
 from sqlalchemy import types
 
 from .. import i18n
@@ -70,8 +69,7 @@ class WeekDaysType(types.TypeDecorator, ScalarCoercible):
             value = value.as_bit_string()
 
         if dialect.name == 'mysql':
-            func = bytes if six.PY3 else bytearray
-            return func(value, 'utf8')
+            return bytes(value, 'utf8')
         return value
 
     def process_result_value(self, value, dialect):

--- a/sqlalchemy_utils/utils.py
+++ b/sqlalchemy_utils/utils.py
@@ -1,7 +1,5 @@
 from collections.abc import Iterable
 
-import six
-
 
 def str_coercible(cls):
     def __str__(self):
@@ -13,7 +11,7 @@ def str_coercible(cls):
 
 def is_sequence(value):
     return (
-        isinstance(value, Iterable) and not isinstance(value, six.string_types)
+        isinstance(value, Iterable) and not isinstance(value, str)
     )
 
 

--- a/tests/aggregate/test_backrefs.py
+++ b/tests/aggregate/test_backrefs.py
@@ -34,7 +34,7 @@ def init_models(Thread, Comment):
     pass
 
 
-class TestAggregateValueGenerationWithBackrefs(object):
+class TestAggregateValueGenerationWithBackrefs:
 
     def test_assigns_aggregates_on_insert(self, session, Thread, Comment):
         thread = Thread()

--- a/tests/aggregate/test_backrefs.py
+++ b/tests/aggregate/test_backrefs.py
@@ -38,9 +38,9 @@ class TestAggregateValueGenerationWithBackrefs(object):
 
     def test_assigns_aggregates_on_insert(self, session, Thread, Comment):
         thread = Thread()
-        thread.name = u'some article name'
+        thread.name = 'some article name'
         session.add(thread)
-        comment = Comment(content=u'Some content', thread=thread)
+        comment = Comment(content='Some content', thread=thread)
         session.add(comment)
         session.commit()
         session.refresh(thread)
@@ -53,10 +53,10 @@ class TestAggregateValueGenerationWithBackrefs(object):
         Comment
     ):
         thread = Thread()
-        thread.name = u'some article name'
+        thread.name = 'some article name'
         session.add(thread)
         session.commit()
-        comment = Comment(content=u'Some content', thread=thread)
+        comment = Comment(content='Some content', thread=thread)
         session.add(comment)
         session.commit()
         session.refresh(thread)
@@ -64,10 +64,10 @@ class TestAggregateValueGenerationWithBackrefs(object):
 
     def test_assigns_aggregates_on_delete(self, session, Thread, Comment):
         thread = Thread()
-        thread.name = u'some article name'
+        thread.name = 'some article name'
         session.add(thread)
         session.commit()
-        comment = Comment(content=u'Some content', thread=thread)
+        comment = Comment(content='Some content', thread=thread)
         session.add(comment)
         session.commit()
         session.delete(comment)

--- a/tests/aggregate/test_custom_select_expressions.py
+++ b/tests/aggregate/test_custom_select_expressions.py
@@ -43,12 +43,12 @@ class TestLazyEvaluatedSelectExpressionsForAggregates(object):
 
     def test_assigns_aggregates_on_insert(self, session, Product, Catalog):
         catalog = Catalog(
-            name=u'Some catalog'
+            name='Some catalog'
         )
         session.add(catalog)
         session.commit()
         product = Product(
-            name=u'Some product',
+            name='Some product',
             price=Decimal('1000'),
             catalog=catalog
         )
@@ -59,12 +59,12 @@ class TestLazyEvaluatedSelectExpressionsForAggregates(object):
 
     def test_assigns_aggregates_on_update(self, session, Product, Catalog):
         catalog = Catalog(
-            name=u'Some catalog'
+            name='Some catalog'
         )
         session.add(catalog)
         session.commit()
         product = Product(
-            name=u'Some product',
+            name='Some product',
             price=Decimal('1000'),
             catalog=catalog
         )

--- a/tests/aggregate/test_custom_select_expressions.py
+++ b/tests/aggregate/test_custom_select_expressions.py
@@ -39,7 +39,7 @@ def init_models(Product, Catalog):
 
 
 @pytest.mark.usefixtures('postgresql_dsn')
-class TestLazyEvaluatedSelectExpressionsForAggregates(object):
+class TestLazyEvaluatedSelectExpressionsForAggregates:
 
     def test_assigns_aggregates_on_insert(self, session, Product, Catalog):
         catalog = Catalog(

--- a/tests/aggregate/test_join_table_inheritance.py
+++ b/tests/aggregate/test_join_table_inheritance.py
@@ -111,12 +111,12 @@ class TestLazyEvaluatedSelectExpressionsForAggregates(object):
 
     def test_assigns_aggregates_on_insert(self, session, AnyProduct, Catalog):
         catalog = Catalog(
-            name=u'Some catalog'
+            name='Some catalog'
         )
         session.add(catalog)
         session.commit()
         product = AnyProduct(
-            name=u'Some product',
+            name='Some product',
             price=Decimal('1000'),
             catalog=catalog
         )
@@ -127,12 +127,12 @@ class TestLazyEvaluatedSelectExpressionsForAggregates(object):
 
     def test_assigns_aggregates_on_update(self, session, Catalog, AnyProduct):
         catalog = Catalog(
-            name=u'Some catalog'
+            name='Some catalog'
         )
         session.add(catalog)
         session.commit()
         product = AnyProduct(
-            name=u'Some product',
+            name='Some product',
             price=Decimal('1000'),
             catalog=catalog
         )

--- a/tests/aggregate/test_join_table_inheritance.py
+++ b/tests/aggregate/test_join_table_inheritance.py
@@ -95,7 +95,7 @@ def init_models(AnyProduct, Catalog, CostumeCatalog, CarCatalog):
 
 
 @pytest.mark.usefixtures('postgresql_dsn')
-class TestLazyEvaluatedSelectExpressionsForAggregates(object):
+class TestLazyEvaluatedSelectExpressionsForAggregates:
 
     def test_columns_inherited_from_parent(
         self,

--- a/tests/aggregate/test_m2m.py
+++ b/tests/aggregate/test_m2m.py
@@ -49,12 +49,12 @@ class TestAggregatesWithManyToManyRelationships(object):
 
     def test_assigns_aggregates_on_insert(self, session, User, Group):
         user = User(
-            name=u'John Matrix'
+            name='John Matrix'
         )
         session.add(user)
         session.commit()
         group = Group(
-            name=u'Some group',
+            name='Some group',
             users=[user]
         )
         session.add(group)
@@ -64,12 +64,12 @@ class TestAggregatesWithManyToManyRelationships(object):
 
     def test_updates_aggregates_on_delete(self, session, User, Group):
         user = User(
-            name=u'John Matrix'
+            name='John Matrix'
         )
         session.add(user)
         session.commit()
         group = Group(
-            name=u'Some group',
+            name='Some group',
             users=[user]
         )
         session.add(group)

--- a/tests/aggregate/test_m2m.py
+++ b/tests/aggregate/test_m2m.py
@@ -45,7 +45,7 @@ def init_models(User, Group):
 
 
 @pytest.mark.usefixtures('postgresql_dsn')
-class TestAggregatesWithManyToManyRelationships(object):
+class TestAggregatesWithManyToManyRelationships:
 
     def test_assigns_aggregates_on_insert(self, session, User, Group):
         user = User(

--- a/tests/aggregate/test_m2m_m2m.py
+++ b/tests/aggregate/test_m2m_m2m.py
@@ -75,7 +75,7 @@ def init_models(Category, Catalog, Product):
 
 
 @pytest.mark.usefixtures('postgresql_dsn')
-class TestAggregateManyToManyAndManyToMany(object):
+class TestAggregateManyToManyAndManyToMany:
 
     def test_insert(self, session, Product, Category, Catalog):
         category = Category()

--- a/tests/aggregate/test_multiple_aggregates_per_class.py
+++ b/tests/aggregate/test_multiple_aggregates_per_class.py
@@ -51,7 +51,7 @@ def init_models(Comment, Thread):
     pass
 
 
-class TestAggregateValueGenerationForSimpleModelPaths(object):
+class TestAggregateValueGenerationForSimpleModelPaths:
 
     def test_assigns_aggregates_on_insert(self, session, Thread, Comment):
         thread = Thread()

--- a/tests/aggregate/test_multiple_aggregates_per_class.py
+++ b/tests/aggregate/test_multiple_aggregates_per_class.py
@@ -55,9 +55,9 @@ class TestAggregateValueGenerationForSimpleModelPaths(object):
 
     def test_assigns_aggregates_on_insert(self, session, Thread, Comment):
         thread = Thread()
-        thread.name = u'some article name'
+        thread.name = 'some article name'
         session.add(thread)
-        comment = Comment(content=u'Some content', thread=thread)
+        comment = Comment(content='Some content', thread=thread)
         session.add(comment)
         session.commit()
         session.refresh(thread)
@@ -71,10 +71,10 @@ class TestAggregateValueGenerationForSimpleModelPaths(object):
         Comment
     ):
         thread = Thread()
-        thread.name = u'some article name'
+        thread.name = 'some article name'
         session.add(thread)
         session.commit()
-        comment = Comment(content=u'Some content', thread=thread)
+        comment = Comment(content='Some content', thread=thread)
         session.add(comment)
         session.commit()
         session.refresh(thread)
@@ -83,10 +83,10 @@ class TestAggregateValueGenerationForSimpleModelPaths(object):
 
     def test_assigns_aggregates_on_delete(self, session, Thread, Comment):
         thread = Thread()
-        thread.name = u'some article name'
+        thread.name = 'some article name'
         session.add(thread)
         session.commit()
-        comment = Comment(content=u'Some content', thread=thread)
+        comment = Comment(content='Some content', thread=thread)
         session.add(comment)
         session.commit()
         session.delete(comment)

--- a/tests/aggregate/test_o2m_m2m.py
+++ b/tests/aggregate/test_o2m_m2m.py
@@ -67,7 +67,7 @@ def init_models(Category, Catalog, Product):
 
 
 @pytest.mark.usefixtures('postgresql_dsn')
-class TestAggregateOneToManyAndManyToMany(object):
+class TestAggregateOneToManyAndManyToMany:
 
     def test_insert(self, session, Category, Catalog, Product):
         category = Category()

--- a/tests/aggregate/test_o2m_o2m.py
+++ b/tests/aggregate/test_o2m_o2m.py
@@ -58,15 +58,15 @@ def init_models(Catalog, Category, Product):
 class TestAggregateOneToManyAndOneToMany(object):
 
     def test_assigns_aggregates(self, session, Category, Catalog, Product):
-        category = Category(name=u'Some category')
+        category = Category(name='Some category')
         catalog = Catalog(
             categories=[category]
         )
-        catalog.name = u'Some catalog'
+        catalog.name = 'Some catalog'
         session.add(catalog)
         session.commit()
         product = Product(
-            name=u'Some product',
+            name='Some product',
             price=Decimal('1000'),
             category=category
         )

--- a/tests/aggregate/test_o2m_o2m.py
+++ b/tests/aggregate/test_o2m_o2m.py
@@ -55,7 +55,7 @@ def init_models(Catalog, Category, Product):
 
 
 @pytest.mark.usefixtures('postgresql_dsn')
-class TestAggregateOneToManyAndOneToMany(object):
+class TestAggregateOneToManyAndOneToMany:
 
     def test_assigns_aggregates(self, session, Category, Catalog, Product):
         category = Category(name='Some category')

--- a/tests/aggregate/test_o2m_o2m_o2m.py
+++ b/tests/aggregate/test_o2m_o2m_o2m.py
@@ -77,7 +77,7 @@ def catalog_factory(Product, SubCategory, Category, Catalog, session):
 
 
 @pytest.mark.usefixtures('postgresql_dsn')
-class Test3LevelDeepOneToMany(object):
+class Test3LevelDeepOneToMany:
 
     def test_assigns_aggregates(self, session, catalog_factory):
         catalog = catalog_factory()

--- a/tests/aggregate/test_search_vectors.py
+++ b/tests/aggregate/test_search_vectors.py
@@ -48,7 +48,7 @@ def init_models(Product, Catalog):
 
 
 @pytest.mark.usefixtures('postgresql_dsn')
-class TestSearchVectorAggregates(object):
+class TestSearchVectorAggregates:
 
     def test_assigns_aggregates_on_insert(self, session, Product, Catalog):
         catalog = Catalog(

--- a/tests/aggregate/test_search_vectors.py
+++ b/tests/aggregate/test_search_vectors.py
@@ -52,12 +52,12 @@ class TestSearchVectorAggregates(object):
 
     def test_assigns_aggregates_on_insert(self, session, Product, Catalog):
         catalog = Catalog(
-            name=u'Some catalog'
+            name='Some catalog'
         )
         session.add(catalog)
         session.commit()
         product = Product(
-            name=u'Product XYZ',
+            name='Product XYZ',
             catalog=catalog
         )
         session.add(product)

--- a/tests/aggregate/test_simple_paths.py
+++ b/tests/aggregate/test_simple_paths.py
@@ -38,9 +38,9 @@ class TestAggregateValueGenerationForSimpleModelPaths(object):
 
     def test_assigns_aggregates_on_insert(self, session, Thread, Comment):
         thread = Thread()
-        thread.name = u'some article name'
+        thread.name = 'some article name'
         session.add(thread)
-        comment = Comment(content=u'Some content', thread=thread)
+        comment = Comment(content='Some content', thread=thread)
         session.add(comment)
         session.commit()
         session.refresh(thread)
@@ -53,10 +53,10 @@ class TestAggregateValueGenerationForSimpleModelPaths(object):
         Comment
     ):
         thread = Thread()
-        thread.name = u'some article name'
+        thread.name = 'some article name'
         session.add(thread)
         session.commit()
-        comment = Comment(content=u'Some content', thread=thread)
+        comment = Comment(content='Some content', thread=thread)
         session.add(comment)
         session.commit()
         session.refresh(thread)
@@ -64,10 +64,10 @@ class TestAggregateValueGenerationForSimpleModelPaths(object):
 
     def test_assigns_aggregates_on_delete(self, session, Thread, Comment):
         thread = Thread()
-        thread.name = u'some article name'
+        thread.name = 'some article name'
         session.add(thread)
         session.commit()
-        comment = Comment(content=u'Some content', thread=thread)
+        comment = Comment(content='Some content', thread=thread)
         session.add(comment)
         session.commit()
         session.delete(comment)

--- a/tests/aggregate/test_simple_paths.py
+++ b/tests/aggregate/test_simple_paths.py
@@ -34,7 +34,7 @@ def init_models(Thread, Comment):
     pass
 
 
-class TestAggregateValueGenerationForSimpleModelPaths(object):
+class TestAggregateValueGenerationForSimpleModelPaths:
 
     def test_assigns_aggregates_on_insert(self, session, Thread, Comment):
         thread = Thread()

--- a/tests/aggregate/test_with_column_alias.py
+++ b/tests/aggregate/test_with_column_alias.py
@@ -35,7 +35,7 @@ def init_models(Thread, Comment):
     pass
 
 
-class TestAggregatedWithColumnAlias(object):
+class TestAggregatedWithColumnAlias:
 
     def test_assigns_aggregates_on_insert(self, session, Thread, Comment):
         thread = Thread()

--- a/tests/aggregate/test_with_ondelete_cascade.py
+++ b/tests/aggregate/test_with_ondelete_cascade.py
@@ -42,7 +42,7 @@ def init_models(Thread, Comment):
 
 
 @pytest.mark.usefixtures('postgresql_dsn')
-class TestAggregateValueGenerationWithCascadeDelete(object):
+class TestAggregateValueGenerationWithCascadeDelete:
 
     def test_something(self, session, Thread, Comment):
         thread = Thread()

--- a/tests/aggregate/test_with_ondelete_cascade.py
+++ b/tests/aggregate/test_with_ondelete_cascade.py
@@ -46,9 +46,9 @@ class TestAggregateValueGenerationWithCascadeDelete(object):
 
     def test_something(self, session, Thread, Comment):
         thread = Thread()
-        thread.name = u'some article name'
+        thread.name = 'some article name'
         session.add(thread)
-        comment = Comment(content=u'Some content', thread=thread)
+        comment = Comment(content='Some content', thread=thread)
         session.add(comment)
         session.commit()
         session.expire_all()

--- a/tests/functions/test_cast_if.py
+++ b/tests/functions/test_cast_if.py
@@ -22,7 +22,7 @@ def article_cls(base):
     return Article
 
 
-class TestCastIf(object):
+class TestCastIf:
     def test_column(self, article_cls):
         expr = article_cls.__table__.c.name
         assert cast_if(expr, sa.String) is expr

--- a/tests/functions/test_database.py
+++ b/tests/functions/test_database.py
@@ -10,7 +10,7 @@ except ImportError:
     pass
 
 
-class DatabaseTest(object):
+class DatabaseTest:
     def test_create_and_drop(self, dsn):
         assert not database_exists(dsn)
         create_database(dsn)
@@ -20,14 +20,14 @@ class DatabaseTest(object):
 
 
 @pytest.mark.usefixtures('sqlite_memory_dsn')
-class TestDatabaseSQLiteMemory(object):
+class TestDatabaseSQLiteMemory:
 
     def test_exists_memory(self, dsn):
         assert database_exists(dsn)
 
 
 @pytest.mark.usefixtures('sqlite_none_database_dsn')
-class TestDatabaseSQLiteMemoryNoDatabaseString(object):
+class TestDatabaseSQLiteMemoryNoDatabaseString:
     def test_exists_memory_none_database(self, sqlite_none_database_dsn):
         assert database_exists(sqlite_none_database_dsn)
 
@@ -116,7 +116,7 @@ class TestDatabasePostgresWithQuotedName(DatabaseTest):
                 'TEMPLATE "my-template"') in str(excinfo.value)
 
 
-class TestDatabasePostgresCreateDatabaseCloseConnection(object):
+class TestDatabasePostgresCreateDatabaseCloseConnection:
     def test_create_database_twice(
         self,
         postgresql_db_user,

--- a/tests/functions/test_dependent_objects.py
+++ b/tests/functions/test_dependent_objects.py
@@ -4,7 +4,7 @@ import sqlalchemy as sa
 from sqlalchemy_utils import dependent_objects, get_referencing_foreign_keys
 
 
-class TestDependentObjects(object):
+class TestDependentObjects:
 
     @pytest.fixture
     def User(self, Base):
@@ -94,7 +94,7 @@ class TestDependentObjects(object):
         assert objects[3] in deps
 
 
-class TestDependentObjectsWithColumnAliases(object):
+class TestDependentObjectsWithColumnAliases:
 
     @pytest.fixture
     def User(self, Base):
@@ -188,7 +188,7 @@ class TestDependentObjectsWithColumnAliases(object):
         assert objects[3] in deps
 
 
-class TestDependentObjectsWithManyReferences(object):
+class TestDependentObjectsWithManyReferences:
 
     @pytest.fixture
     def User(self, Base):
@@ -233,7 +233,7 @@ class TestDependentObjectsWithManyReferences(object):
         assert len(deps) == 2
 
 
-class TestDependentObjectsWithCompositeKeys(object):
+class TestDependentObjectsWithCompositeKeys:
 
     @pytest.fixture
     def User(self, Base):
@@ -281,7 +281,7 @@ class TestDependentObjectsWithCompositeKeys(object):
         assert articles[3] in deps
 
 
-class TestDependentObjectsWithSingleTableInheritance(object):
+class TestDependentObjectsWithSingleTableInheritance:
 
     @pytest.fixture
     def Category(self, Base):

--- a/tests/functions/test_dependent_objects.py
+++ b/tests/functions/test_dependent_objects.py
@@ -46,7 +46,7 @@ class TestDependentObjects(object):
         pass
 
     def test_returns_all_dependent_objects(self, session, User, Article):
-        user = User(first_name=u'John')
+        user = User(first_name='John')
         articles = [
             Article(author=user),
             Article(),
@@ -69,7 +69,7 @@ class TestDependentObjects(object):
         Article,
         BlogPost
     ):
-        user = User(first_name=u'John')
+        user = User(first_name='John')
         objects = [
             Article(author=user),
             Article(),
@@ -140,7 +140,7 @@ class TestDependentObjectsWithColumnAliases(object):
         pass
 
     def test_returns_all_dependent_objects(self, session, User, Article):
-        user = User(first_name=u'John')
+        user = User(first_name='John')
         articles = [
             Article(author=user),
             Article(),
@@ -163,7 +163,7 @@ class TestDependentObjectsWithColumnAliases(object):
         Article,
         BlogPost
     ):
-        user = User(first_name=u'John')
+        user = User(first_name='John')
         objects = [
             Article(author=user),
             Article(),
@@ -222,7 +222,7 @@ class TestDependentObjectsWithManyReferences(object):
         pass
 
     def test_with_many_dependencies(self, session, User, Article, BlogPost):
-        user = User(first_name=u'John')
+        user = User(first_name='John')
         objects = [
             Article(author=user),
             BlogPost(author=user)
@@ -265,7 +265,7 @@ class TestDependentObjectsWithCompositeKeys(object):
         pass
 
     def test_returns_all_dependent_objects(self, session, User, Article):
-        user = User(first_name=u'John', last_name=u'Smith')
+        user = User(first_name='John', last_name='Smith')
         articles = [
             Article(author=user),
             Article(),
@@ -318,7 +318,7 @@ class TestDependentObjectsWithSingleTableInheritance(object):
     def Article(self, TextItem):
         class Article(TextItem):
             __mapper_args__ = {
-                'polymorphic_identity': u'article'
+                'polymorphic_identity': 'article'
             }
         return Article
 
@@ -326,7 +326,7 @@ class TestDependentObjectsWithSingleTableInheritance(object):
     def BlogPost(self, TextItem):
         class BlogPost(TextItem):
             __mapper_args__ = {
-                'polymorphic_identity': u'blog_post'
+                'polymorphic_identity': 'blog_post'
             }
         return BlogPost
 
@@ -335,8 +335,8 @@ class TestDependentObjectsWithSingleTableInheritance(object):
         pass
 
     def test_returns_all_dependent_objects(self, session, Category, Article):
-        category1 = Category(name=u'Category #1')
-        category2 = Category(name=u'Category #2')
+        category1 = Category(name='Category #1')
+        category2 = Category(name='Category #2')
         articles = [
             Article(category=category1),
             Article(category=category1),

--- a/tests/functions/test_escape_like.py
+++ b/tests/functions/test_escape_like.py
@@ -1,6 +1,6 @@
 from sqlalchemy_utils import escape_like
 
 
-class TestEscapeLike(object):
+class TestEscapeLike:
     def test_escapes_wildcards(self):
         assert escape_like('_*%') == '*_***%'

--- a/tests/functions/test_get_bind.py
+++ b/tests/functions/test_get_bind.py
@@ -3,7 +3,7 @@ import pytest
 from sqlalchemy_utils import get_bind
 
 
-class TestGetBind(object):
+class TestGetBind:
     def test_with_session(self, session, connection):
         assert get_bind(session) == connection
 

--- a/tests/functions/test_get_class_by_table.py
+++ b/tests/functions/test_get_class_by_table.py
@@ -4,7 +4,7 @@ import sqlalchemy as sa
 from sqlalchemy_utils import get_class_by_table
 
 
-class TestGetClassByTableWithJoinedTableInheritance(object):
+class TestGetClassByTableWithJoinedTableInheritance:
 
     @pytest.fixture
     def Entity(self, Base):
@@ -49,7 +49,7 @@ class TestGetClassByTableWithJoinedTableInheritance(object):
         assert get_class_by_table(Base, table) is None
 
 
-class TestGetClassByTableWithSingleTableInheritance(object):
+class TestGetClassByTableWithSingleTableInheritance:
 
     @pytest.fixture
     def Entity(self, Base):

--- a/tests/functions/test_get_column_key.py
+++ b/tests/functions/test_get_column_key.py
@@ -23,7 +23,7 @@ def Movie(Base):
     return Movie
 
 
-class TestGetColumnKey(object):
+class TestGetColumnKey:
 
     def test_supports_aliases(self, Building):
         assert (

--- a/tests/functions/test_get_columns.py
+++ b/tests/functions/test_get_columns.py
@@ -18,7 +18,7 @@ def columns():
     return ['_id', '_name']
 
 
-class TestGetColumns(object):
+class TestGetColumns:
     def test_table(self, Building):
         assert isinstance(
             get_columns(Building.__table__),

--- a/tests/functions/test_get_hybrid_properties.py
+++ b/tests/functions/test_get_hybrid_properties.py
@@ -22,7 +22,7 @@ def Category(Base):
     return Category
 
 
-class TestGetHybridProperties(object):
+class TestGetHybridProperties:
 
     def test_declarative_model(self, Category):
         assert (

--- a/tests/functions/test_get_mapper.py
+++ b/tests/functions/test_get_mapper.py
@@ -5,7 +5,7 @@ from sqlalchemy_utils import get_mapper
 from sqlalchemy_utils.functions.orm import _get_query_compile_state
 
 
-class TestGetMapper(object):
+class TestGetMapper:
 
     @pytest.fixture
     def Building(self, Base):
@@ -66,7 +66,7 @@ class TestGetMapper(object):
         )
 
 
-class TestGetMapperWithQueryEntities(object):
+class TestGetMapperWithQueryEntities:
 
     @pytest.fixture
     def Building(self, Base):
@@ -95,7 +95,7 @@ class TestGetMapperWithQueryEntities(object):
         assert get_mapper(entity) == sa.inspect(Building)
 
 
-class TestGetMapperWithMultipleMappersFound(object):
+class TestGetMapperWithMultipleMappersFound:
 
     @pytest.fixture
     def Building(self, Base):
@@ -118,7 +118,7 @@ class TestGetMapperWithMultipleMappersFound(object):
             get_mapper(alias)
 
 
-class TestGetMapperForTableWithoutMapper(object):
+class TestGetMapperForTableWithoutMapper:
 
     @pytest.fixture
     def building(self):

--- a/tests/functions/test_get_primary_keys.py
+++ b/tests/functions/test_get_primary_keys.py
@@ -18,7 +18,7 @@ def Building(Base):
     return Building
 
 
-class TestGetPrimaryKeys(object):
+class TestGetPrimaryKeys:
 
     def test_table(self, Building):
         assert get_primary_keys(Building.__table__) == OrderedDict({

--- a/tests/functions/test_get_referencing_foreign_keys.py
+++ b/tests/functions/test_get_referencing_foreign_keys.py
@@ -4,7 +4,7 @@ import sqlalchemy as sa
 from sqlalchemy_utils import get_referencing_foreign_keys
 
 
-class TestGetReferencingFksWithCompositeKeys(object):
+class TestGetReferencingFksWithCompositeKeys:
 
     @pytest.fixture
     def User(self, Base):
@@ -42,7 +42,7 @@ class TestGetReferencingFksWithCompositeKeys(object):
         assert Article.__table__.foreign_keys == fks
 
 
-class TestGetReferencingFksWithInheritance(object):
+class TestGetReferencingFksWithInheritance:
 
     @pytest.fixture
     def User(self, Base):

--- a/tests/functions/test_get_tables.py
+++ b/tests/functions/test_get_tables.py
@@ -38,7 +38,7 @@ def init_models(TextItem, Article):
     pass
 
 
-class TestGetTables(object):
+class TestGetTables:
 
     def test_child_class_using_join_table_inheritance(self, TextItem, Article):
         assert get_tables(Article) == [

--- a/tests/functions/test_get_tables.py
+++ b/tests/functions/test_get_tables.py
@@ -28,7 +28,7 @@ def Article(TextItem):
             sa.Integer, sa.ForeignKey(TextItem.id), primary_key=True
         )
         __mapper_args__ = {
-            'polymorphic_identity': u'article'
+            'polymorphic_identity': 'article'
         }
     return Article
 

--- a/tests/functions/test_get_type.py
+++ b/tests/functions/test_get_type.py
@@ -28,7 +28,7 @@ def Article(Base, User):
     return Article
 
 
-class TestGetType(object):
+class TestGetType:
 
     def test_instrumented_attribute(self, Article):
         assert isinstance(get_type(Article.id), sa.Integer)

--- a/tests/functions/test_getdotattr.py
+++ b/tests/functions/test_getdotattr.py
@@ -66,7 +66,7 @@ def init_models(Document, Section, SubSection, SubSubSection):
     pass
 
 
-class TestGetDotAttr(object):
+class TestGetDotAttr:
 
     def test_simple_objects(self, Document, Section, SubSection):
         document = Document(name='some document')

--- a/tests/functions/test_getdotattr.py
+++ b/tests/functions/test_getdotattr.py
@@ -69,14 +69,14 @@ def init_models(Document, Section, SubSection, SubSubSection):
 class TestGetDotAttr(object):
 
     def test_simple_objects(self, Document, Section, SubSection):
-        document = Document(name=u'some document')
+        document = Document(name='some document')
         section = Section(document=document)
         subsection = SubSection(section=section)
 
         assert getdotattr(
             subsection,
             'section.document.name'
-        ) == u'some document'
+        ) == 'some document'
 
     def test_with_instrumented_lists(
         self,
@@ -85,7 +85,7 @@ class TestGetDotAttr(object):
         SubSection,
         SubSubSection
     ):
-        document = Document(name=u'some document')
+        document = Document(name='some document')
         section = Section(document=document)
         subsection = SubSection(section=section)
         subsubsection = SubSubSection(subsection=subsection)

--- a/tests/functions/test_has_changes.py
+++ b/tests/functions/test_has_changes.py
@@ -13,7 +13,7 @@ def Article(Base):
     return Article
 
 
-class TestHasChangesWithStringAttr(object):
+class TestHasChangesWithStringAttr:
     def test_without_changed_attr(self, Article):
         article = Article()
         assert not has_changes(article, 'title')
@@ -23,7 +23,7 @@ class TestHasChangesWithStringAttr(object):
         assert has_changes(article, 'title')
 
 
-class TestHasChangesWithMultipleAttrs(object):
+class TestHasChangesWithMultipleAttrs:
     def test_without_changed_attr(self, Article):
         article = Article()
         assert not has_changes(article, ['title'])
@@ -33,7 +33,7 @@ class TestHasChangesWithMultipleAttrs(object):
         assert has_changes(article, ['title', 'id'])
 
 
-class TestHasChangesWithExclude(object):
+class TestHasChangesWithExclude:
     def test_without_changed_attr(self, Article):
         article = Article()
         assert not has_changes(article, exclude=['id'])

--- a/tests/functions/test_has_index.py
+++ b/tests/functions/test_has_index.py
@@ -4,7 +4,7 @@ import sqlalchemy as sa
 from sqlalchemy_utils import get_fk_constraint_for_columns, has_index
 
 
-class TestHasIndex(object):
+class TestHasIndex:
 
     @pytest.fixture
     def table(self, Base):
@@ -47,7 +47,7 @@ class TestHasIndex(object):
         assert not has_index(article.c.name)
 
 
-class TestHasIndexWithFKConstraint(object):
+class TestHasIndexWithFKConstraint:
     def test_composite_fk_without_index(self, Base):
 
         class User(Base):

--- a/tests/functions/test_has_unique_index.py
+++ b/tests/functions/test_has_unique_index.py
@@ -4,7 +4,7 @@ import sqlalchemy as sa
 from sqlalchemy_utils import get_fk_constraint_for_columns, has_unique_index
 
 
-class TestHasUniqueIndex(object):
+class TestHasUniqueIndex:
 
     @pytest.fixture
     def articles(self, Base):
@@ -53,7 +53,7 @@ class TestHasUniqueIndex(object):
         assert not has_unique_index(article_translations.c.is_archived)
 
 
-class TestHasUniqueIndexWithFKConstraint(object):
+class TestHasUniqueIndexWithFKConstraint:
     def test_composite_fk_without_index(self, Base):
 
         class User(Base):

--- a/tests/functions/test_identity.py
+++ b/tests/functions/test_identity.py
@@ -14,7 +14,7 @@ class IdentityTestCase(object):
         assert identity(Building()) == (None, )
 
     def test_for_transient_class_with_id(self, session, Building):
-        building = Building(name=u'Some building')
+        building = Building(name='Some building')
         session.add(building)
         session.flush()
 

--- a/tests/functions/test_identity.py
+++ b/tests/functions/test_identity.py
@@ -4,7 +4,7 @@ import sqlalchemy as sa
 from sqlalchemy_utils.functions import identity
 
 
-class IdentityTestCase(object):
+class IdentityTestCase:
 
     @pytest.fixture
     def init_models(self, Building):

--- a/tests/functions/test_is_loaded.py
+++ b/tests/functions/test_is_loaded.py
@@ -13,7 +13,7 @@ def Article(Base):
     return Article
 
 
-class TestIsLoaded(object):
+class TestIsLoaded:
 
     def test_loaded_property(self, Article):
         article = Article(id=1)

--- a/tests/functions/test_json_sql.py
+++ b/tests/functions/test_json_sql.py
@@ -5,7 +5,7 @@ from sqlalchemy_utils import json_sql
 
 
 @pytest.mark.usefixtures('postgresql_dsn')
-class TestJSONSQL(object):
+class TestJSONSQL:
 
     @pytest.mark.parametrize(
         ('value', 'result'),

--- a/tests/functions/test_jsonb_sql.py
+++ b/tests/functions/test_jsonb_sql.py
@@ -5,7 +5,7 @@ from sqlalchemy_utils import jsonb_sql
 
 
 @pytest.mark.usefixtures('postgresql_dsn')
-class TestJSONBSQL(object):
+class TestJSONBSQL:
 
     @pytest.mark.parametrize(
         ('value', 'result'),

--- a/tests/functions/test_make_order_by_deterministic.py
+++ b/tests/functions/test_make_order_by_deterministic.py
@@ -41,7 +41,7 @@ def init_models(Article, User):
     pass
 
 
-class TestMakeOrderByDeterministic(object):
+class TestMakeOrderByDeterministic:
 
     def test_column_property(self, session, User):
         query = session.query(User).order_by(User.email_lower)

--- a/tests/functions/test_merge_references.py
+++ b/tests/functions/test_merge_references.py
@@ -4,7 +4,7 @@ import sqlalchemy as sa
 from sqlalchemy_utils import merge_references
 
 
-class TestMergeReferences(object):
+class TestMergeReferences:
 
     @pytest.fixture
     def User(self, Base):
@@ -65,7 +65,7 @@ class TestMergeReferences(object):
         assert post2.author_id == jack.id
 
 
-class TestMergeReferencesWithManyToManyAssociations(object):
+class TestMergeReferencesWithManyToManyAssociations:
 
     @pytest.fixture
     def User(self, Base):
@@ -123,7 +123,7 @@ class TestMergeReferencesWithManyToManyAssociations(object):
         assert jack in team.members
 
 
-class TestMergeReferencesWithManyToManyAssociationObjects(object):
+class TestMergeReferencesWithManyToManyAssociationObjects:
 
     @pytest.fixture
     def Team(self, Base):
@@ -194,7 +194,7 @@ class TestMergeReferencesWithManyToManyAssociationObjects(object):
         assert jack in users
 
 
-class TestMergeReferencesWithMappedProperties(object):
+class TestMergeReferencesWithMappedProperties:
 
     @pytest.fixture
     def User(self, Base):

--- a/tests/functions/test_merge_references.py
+++ b/tests/functions/test_merge_references.py
@@ -34,10 +34,10 @@ class TestMergeReferences(object):
         pass
 
     def test_updates_foreign_keys(self, session, User, BlogPost):
-        john = User(name=u'John')
-        jack = User(name=u'Jack')
-        post = BlogPost(title=u'Some title', author=john)
-        post2 = BlogPost(title=u'Other title', author=jack)
+        john = User(name='John')
+        jack = User(name='Jack')
+        post = BlogPost(title='Some title', author=john)
+        post2 = BlogPost(title='Other title', author=jack)
         session.add(john)
         session.add(jack)
         session.add(post)
@@ -49,10 +49,10 @@ class TestMergeReferences(object):
         assert post2.author == jack
 
     def test_object_merging_whenever_possible(self, session, User, BlogPost):
-        john = User(name=u'John')
-        jack = User(name=u'Jack')
-        post = BlogPost(title=u'Some title', author=john)
-        post2 = BlogPost(title=u'Other title', author=jack)
+        john = User(name='John')
+        jack = User(name='Jack')
+        post = BlogPost(title='Some title', author=john)
+        post2 = BlogPost(title='Other title', author=jack)
         session.add(john)
         session.add(jack)
         session.add(post)
@@ -111,9 +111,9 @@ class TestMergeReferencesWithManyToManyAssociations(object):
         pass
 
     def test_supports_associations(self, session, User, Team):
-        john = User(name=u'John')
-        jack = User(name=u'Jack')
-        team = Team(name=u'Team')
+        john = User(name='John')
+        jack = User(name='Jack')
+        team = Team(name='Team')
         team.members.append(john)
         session.add(john)
         session.add(jack)
@@ -179,9 +179,9 @@ class TestMergeReferencesWithManyToManyAssociationObjects(object):
         pass
 
     def test_supports_associations(self, session, User, Team, TeamMember):
-        john = User(name=u'John')
-        jack = User(name=u'Jack')
-        team = Team(name=u'Team')
+        john = User(name='John')
+        jack = User(name='Jack')
+        team = Team(name='Team')
         team.members.append(TeamMember(user=john))
         session.add(john)
         session.add(jack)
@@ -240,9 +240,9 @@ class TestMergeReferencesWithMappedProperties(object):
         pass
 
     def test_supports_associations(self, session, User, Team):
-        john = User(name=u'John')
-        jack = User(name=u'Jack')
-        team = Team(name=u'Team')
+        john = User(name='John')
+        jack = User(name='Jack')
+        team = Team(name='Team')
         team.members.append(john)
         session.add(john)
         session.add(jack)

--- a/tests/functions/test_naturally_equivalent.py
+++ b/tests/functions/test_naturally_equivalent.py
@@ -1,7 +1,7 @@
 from sqlalchemy_utils.functions import naturally_equivalent
 
 
-class TestNaturallyEquivalent(object):
+class TestNaturallyEquivalent:
     def test_returns_true_when_properties_match(self, User):
         assert naturally_equivalent(
             User(name='someone'), User(name='someone')

--- a/tests/functions/test_naturally_equivalent.py
+++ b/tests/functions/test_naturally_equivalent.py
@@ -4,10 +4,10 @@ from sqlalchemy_utils.functions import naturally_equivalent
 class TestNaturallyEquivalent(object):
     def test_returns_true_when_properties_match(self, User):
         assert naturally_equivalent(
-            User(name=u'someone'), User(name=u'someone')
+            User(name='someone'), User(name='someone')
         )
 
     def test_skips_primary_keys(self, User):
         assert naturally_equivalent(
-            User(id=1, name=u'someone'), User(id=2, name=u'someone')
+            User(id=1, name='someone'), User(id=2, name='someone')
         )

--- a/tests/functions/test_non_indexed_foreign_keys.py
+++ b/tests/functions/test_non_indexed_foreign_keys.py
@@ -6,7 +6,7 @@ import sqlalchemy as sa
 from sqlalchemy_utils.functions import non_indexed_foreign_keys
 
 
-class TestFindNonIndexedForeignKeys(object):
+class TestFindNonIndexedForeignKeys:
 
     @pytest.fixture
     def User(self, Base):

--- a/tests/functions/test_quote.py
+++ b/tests/functions/test_quote.py
@@ -3,7 +3,7 @@ from sqlalchemy.dialects import postgresql
 from sqlalchemy_utils.functions import quote
 
 
-class TestQuote(object):
+class TestQuote:
     def test_quote_with_preserved_keyword(self, engine, connection, session):
         assert quote(connection, 'order') == '"order"'
         assert quote(session, 'order') == '"order"'

--- a/tests/functions/test_render.py
+++ b/tests/functions/test_render.py
@@ -8,7 +8,7 @@ from sqlalchemy_utils.functions import (
 )
 
 
-class TestRender(object):
+class TestRender:
 
     @pytest.fixture
     def User(self, Base):

--- a/tests/functions/test_table_name.py
+++ b/tests/functions/test_table_name.py
@@ -18,7 +18,7 @@ def init_models(Base):
     pass
 
 
-class TestTableName(object):
+class TestTableName:
 
     def test_class(self, Building):
         assert table_name(Building) == 'building'

--- a/tests/generic_relationship/__init__.py
+++ b/tests/generic_relationship/__init__.py
@@ -1,6 +1,3 @@
-import six
-
-
 class GenericRelationshipTestCase(object):
     def test_set_as_none(self, Event):
         event = Event()
@@ -15,7 +12,7 @@ class GenericRelationshipTestCase(object):
 
         event = Event()
         event.object_id = user.id
-        event.object_type = six.text_type(type(user).__name__)
+        event.object_type = str(type(user).__name__)
 
         assert event.object is None
 

--- a/tests/generic_relationship/__init__.py
+++ b/tests/generic_relationship/__init__.py
@@ -1,4 +1,4 @@
-class GenericRelationshipTestCase(object):
+class GenericRelationshipTestCase:
     def test_set_as_none(self, Event):
         event = Event()
         event.object = None

--- a/tests/generic_relationship/test_composite_keys.py
+++ b/tests/generic_relationship/test_composite_keys.py
@@ -1,5 +1,4 @@
 import pytest
-import six
 import sqlalchemy as sa
 
 from sqlalchemy_utils import generic_relationship
@@ -73,7 +72,7 @@ class TestGenericRelationship(GenericRelationshipTestCase):
 
         event = Event()
         event.object_id = user.id
-        event.object_type = six.text_type(type(user).__name__)
+        event.object_type = type(user).__name__
         event.object_code = user.code
 
         assert event.object is None

--- a/tests/generic_relationship/test_composite_keys.py
+++ b/tests/generic_relationship/test_composite_keys.py
@@ -8,7 +8,7 @@ from ..generic_relationship import GenericRelationshipTestCase
 
 @pytest.fixture
 def incrementor():
-    class Incrementor(object):
+    class Incrementor:
         value = 1
     return Incrementor()
 

--- a/tests/generic_relationship/test_hybrid_properties.py
+++ b/tests/generic_relationship/test_hybrid_properties.py
@@ -57,7 +57,7 @@ def init_models(User, UserHistory, Event):
     pass
 
 
-class TestGenericRelationship(object):
+class TestGenericRelationship:
 
     def test_set_manual_and_get(self, session, User, UserHistory, Event):
         user = User(id=1)

--- a/tests/generic_relationship/test_hybrid_properties.py
+++ b/tests/generic_relationship/test_hybrid_properties.py
@@ -1,5 +1,4 @@
 import pytest
-import six
 import sqlalchemy as sa
 from sqlalchemy.ext.hybrid import hybrid_property
 
@@ -69,7 +68,7 @@ class TestGenericRelationship(object):
 
         event = Event(transaction_id=1)
         event.object_id = user.id
-        event.object_type = six.text_type(type(user).__name__)
+        event.object_type = type(user).__name__
         assert event.object is None
 
         session.add(event)

--- a/tests/generic_relationship/test_single_table_inheritance.py
+++ b/tests/generic_relationship/test_single_table_inheritance.py
@@ -55,7 +55,7 @@ def init_models(Employee, Manager, Engineer, Event):
     pass
 
 
-class TestGenericRelationship(object):
+class TestGenericRelationship:
 
     def test_set_as_none(self, Event):
         event = Event()

--- a/tests/generic_relationship/test_single_table_inheritance.py
+++ b/tests/generic_relationship/test_single_table_inheritance.py
@@ -1,5 +1,4 @@
 import pytest
-import six
 import sqlalchemy as sa
 
 from sqlalchemy_utils import generic_relationship
@@ -71,7 +70,7 @@ class TestGenericRelationship(object):
 
         event = Event()
         event.object_id = manager.id
-        event.object_type = six.text_type(type(manager).__name__)
+        event.object_type = type(manager).__name__
 
         assert event.object is None
 

--- a/tests/mixins.py
+++ b/tests/mixins.py
@@ -2,7 +2,7 @@ import pytest
 import sqlalchemy as sa
 
 
-class ThreeLevelDeepOneToOne(object):
+class ThreeLevelDeepOneToOne:
 
     @pytest.fixture
     def Catalog(self, Base, Category):
@@ -70,7 +70,7 @@ class ThreeLevelDeepOneToOne(object):
         pass
 
 
-class ThreeLevelDeepOneToMany(object):
+class ThreeLevelDeepOneToMany:
 
     @pytest.fixture
     def Catalog(self, Base, Category):
@@ -135,7 +135,7 @@ class ThreeLevelDeepOneToMany(object):
         pass
 
 
-class ThreeLevelDeepManyToMany(object):
+class ThreeLevelDeepManyToMany:
 
     @pytest.fixture
     def Catalog(self, Base, Category):

--- a/tests/observes/test_column_property.py
+++ b/tests/observes/test_column_property.py
@@ -5,7 +5,7 @@ from sqlalchemy_utils.observer import observes
 
 
 @pytest.mark.usefixtures('postgresql_dsn')
-class TestObservesForColumn(object):
+class TestObservesForColumn:
 
     @pytest.fixture
     def Product(self, Base):
@@ -31,7 +31,7 @@ class TestObservesForColumn(object):
 
 
 @pytest.mark.usefixtures('postgresql_dsn')
-class TestObservesForColumnWithoutActualChanges(object):
+class TestObservesForColumnWithoutActualChanges:
 
     @pytest.fixture
     def Product(self, Base):
@@ -61,7 +61,7 @@ class TestObservesForColumnWithoutActualChanges(object):
 
 
 @pytest.mark.usefixtures('postgresql_dsn')
-class TestObservesForMultipleColumns(object):
+class TestObservesForMultipleColumns:
 
     @pytest.fixture
     def Order(self, Base):
@@ -98,7 +98,7 @@ class TestObservesForMultipleColumns(object):
 
 
 @pytest.mark.usefixtures('postgresql_dsn')
-class TestObservesForMultipleColumnsFiresOnlyOnce(object):
+class TestObservesForMultipleColumnsFiresOnlyOnce:
 
     @pytest.fixture
     def Order(self, Base):

--- a/tests/observes/test_m2m_m2m_m2m.py
+++ b/tests/observes/test_m2m_m2m_m2m.py
@@ -113,7 +113,7 @@ def catalog(session, Catalog, Category, SubCategory, Product):
 
 
 @pytest.mark.usefixtures('postgresql_dsn')
-class TestObservesForManyToManyToManyToMany(object):
+class TestObservesForManyToManyToManyToMany:
 
     def test_simple_insert(self, catalog):
         assert catalog.product_count == 1

--- a/tests/observes/test_o2m_o2m_o2m.py
+++ b/tests/observes/test_o2m_o2m_o2m.py
@@ -77,7 +77,7 @@ def catalog(session, Catalog, Category, SubCategory, Product):
 
 
 @pytest.mark.usefixtures('postgresql_dsn')
-class TestObservesFor3LevelDeepOneToMany(object):
+class TestObservesFor3LevelDeepOneToMany:
 
     def test_simple_insert(self, catalog):
         assert catalog.product_count == 1

--- a/tests/observes/test_o2m_o2o_o2m.py
+++ b/tests/observes/test_o2m_o2o_o2m.py
@@ -73,7 +73,7 @@ def catalog(session, Catalog, Category, SubCategory, Product):
 
 
 @pytest.mark.usefixtures('postgresql_dsn')
-class TestObservesForOneToManyToOneToMany(object):
+class TestObservesForOneToManyToOneToMany:
 
     def test_simple_insert(self, catalog):
         assert catalog.product_count == 1

--- a/tests/observes/test_o2o_o2o.py
+++ b/tests/observes/test_o2o_o2o.py
@@ -58,7 +58,7 @@ def init_models(Device, Order, SalesInvoice):
 
 
 @pytest.mark.usefixtures('postgresql_dsn')
-class TestObservesForOneToManyToOneToMany(object):
+class TestObservesForOneToManyToOneToMany:
 
     def test_observable_root_obj_is_none(self, session, Device, Order):
         order = Order(device=Device(name='Something'))

--- a/tests/observes/test_o2o_o2o_o2o.py
+++ b/tests/observes/test_o2o_o2o_o2o.py
@@ -81,7 +81,7 @@ def catalog(session, Catalog, Category, SubCategory, Product):
 
 
 @pytest.mark.usefixtures('postgresql_dsn')
-class TestObservesForOneToOneToOneToOne(object):
+class TestObservesForOneToOneToOneToOne:
 
     def test_simple_insert(self, catalog):
         assert catalog.product_price == 123

--- a/tests/primitives/test_country.py
+++ b/tests/primitives/test_country.py
@@ -1,7 +1,6 @@
 import operator
 
 import pytest
-import six
 
 from sqlalchemy_utils import Country, i18n
 
@@ -93,7 +92,7 @@ class TestCountry(object):
 
     def test_unicode(self):
         country = Country('FI')
-        assert six.text_type(country) == u'Finland'
+        assert str(country) == u'Finland'
 
     def test_str(self):
         country = Country('FI')

--- a/tests/primitives/test_country.py
+++ b/tests/primitives/test_country.py
@@ -12,7 +12,7 @@ def set_get_locale():
 
 @pytest.mark.skipif('i18n.babel is None')
 @pytest.mark.usefixtures('set_get_locale')
-class TestCountry(object):
+class TestCountry:
 
     def test_init(self):
         assert Country('FI') == Country(Country('FI'))

--- a/tests/primitives/test_country.py
+++ b/tests/primitives/test_country.py
@@ -15,7 +15,7 @@ def set_get_locale():
 class TestCountry(object):
 
     def test_init(self):
-        assert Country(u'FI') == Country(Country(u'FI'))
+        assert Country('FI') == Country(Country('FI'))
 
     def test_constructor_with_wrong_type(self):
         with pytest.raises(TypeError) as e:
@@ -49,32 +49,32 @@ class TestCountry(object):
         )
 
     def test_equality_operator(self):
-        assert Country(u'FI') == u'FI'
-        assert u'FI' == Country(u'FI')
-        assert Country(u'FI') == Country(u'FI')
+        assert Country('FI') == 'FI'
+        assert 'FI' == Country('FI')
+        assert Country('FI') == Country('FI')
 
     def test_non_equality_operator(self):
-        assert Country(u'FI') != u'sv'
-        assert not (Country(u'FI') != u'FI')
+        assert Country('FI') != 'sv'
+        assert not (Country('FI') != 'FI')
 
     @pytest.mark.parametrize(
         'op, code_left, code_right, is_',
         [
-            (operator.lt, u'ES', u'FI', True),
-            (operator.lt, u'FI', u'ES', False),
-            (operator.lt, u'ES', u'ES', False),
+            (operator.lt, 'ES', 'FI', True),
+            (operator.lt, 'FI', 'ES', False),
+            (operator.lt, 'ES', 'ES', False),
 
-            (operator.le, u'ES', u'FI', True),
-            (operator.le, u'FI', u'ES', False),
-            (operator.le, u'ES', u'ES', True),
+            (operator.le, 'ES', 'FI', True),
+            (operator.le, 'FI', 'ES', False),
+            (operator.le, 'ES', 'ES', True),
 
-            (operator.ge, u'ES', u'FI', False),
-            (operator.ge, u'FI', u'ES', True),
-            (operator.ge, u'ES', u'ES', True),
+            (operator.ge, 'ES', 'FI', False),
+            (operator.ge, 'FI', 'ES', True),
+            (operator.ge, 'ES', 'ES', True),
 
-            (operator.gt, u'ES', u'FI', False),
-            (operator.gt, u'FI', u'ES', True),
-            (operator.gt, u'ES', u'ES', False),
+            (operator.gt, 'ES', 'FI', False),
+            (operator.gt, 'FI', 'ES', True),
+            (operator.gt, 'ES', 'ES', False),
         ]
     )
     def test_ordering(self, op, code_left, code_right, is_):
@@ -92,7 +92,7 @@ class TestCountry(object):
 
     def test_unicode(self):
         country = Country('FI')
-        assert str(country) == u'Finland'
+        assert str(country) == 'Finland'
 
     def test_str(self):
         country = Country('FI')

--- a/tests/primitives/test_currency.py
+++ b/tests/primitives/test_currency.py
@@ -40,8 +40,8 @@ class TestCurrency(object):
     @pytest.mark.parametrize(
         ('code', 'symbol'),
         (
-            ('USD', u'$'),
-            ('EUR', u'€')
+            ('USD', '$'),
+            ('EUR', '€')
         )
     )
     def test_symbol_property(self, code, symbol):
@@ -58,7 +58,7 @@ class TestCurrency(object):
 
     def test_unicode(self):
         currency = Currency('USD')
-        assert str(currency) == u'USD'
+        assert str(currency) == 'USD'
 
     def test_str(self):
         currency = Currency('USD')

--- a/tests/primitives/test_currency.py
+++ b/tests/primitives/test_currency.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import pytest
-import six
 
 from sqlalchemy_utils import Currency, i18n
 
@@ -59,7 +58,7 @@ class TestCurrency(object):
 
     def test_unicode(self):
         currency = Currency('USD')
-        assert six.text_type(currency) == u'USD'
+        assert str(currency) == u'USD'
 
     def test_str(self):
         currency = Currency('USD')

--- a/tests/primitives/test_currency.py
+++ b/tests/primitives/test_currency.py
@@ -11,7 +11,7 @@ def set_get_locale():
 
 @pytest.mark.skipif('i18n.babel is None')
 @pytest.mark.usefixtures('set_get_locale')
-class TestCurrency(object):
+class TestCurrency:
 
     def test_init(self):
         assert Currency('USD') == Currency(Currency('USD'))

--- a/tests/primitives/test_currency.py
+++ b/tests/primitives/test_currency.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import pytest
 
 from sqlalchemy_utils import Currency, i18n

--- a/tests/primitives/test_ltree.py
+++ b/tests/primitives/test_ltree.py
@@ -186,7 +186,7 @@ class TestLtree(object):
         assert Ltree('path.path') == Ltree('path.path')
 
     def test_non_equality_operator(self):
-        assert Ltree('path.path') != u'path.'
+        assert Ltree('path.path') != 'path.'
         assert not (Ltree('path.path') != 'path.path')
 
     def test_hash(self):

--- a/tests/primitives/test_ltree.py
+++ b/tests/primitives/test_ltree.py
@@ -4,7 +4,7 @@ import pytest
 from sqlalchemy_utils import Ltree
 
 
-class TestLtree(object):
+class TestLtree:
     def test_init(self):
         assert Ltree('path.path') == Ltree(Ltree('path.path'))
 

--- a/tests/primitives/test_ltree.py
+++ b/tests/primitives/test_ltree.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import pytest
-import six
 
 from sqlalchemy_utils import Ltree
 
@@ -198,7 +197,7 @@ class TestLtree(object):
 
     def test_unicode(self):
         ltree = Ltree('path.path')
-        assert six.text_type(ltree) == 'path.path'
+        assert str(ltree) == 'path.path'
 
     def test_str(self):
         ltree = Ltree('path')

--- a/tests/primitives/test_ltree.py
+++ b/tests/primitives/test_ltree.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import pytest
 
 from sqlalchemy_utils import Ltree

--- a/tests/primitives/test_weekdays.py
+++ b/tests/primitives/test_weekdays.py
@@ -1,5 +1,4 @@
 import pytest
-import six
 from flexmock import flexmock
 
 from sqlalchemy_utils import i18n
@@ -78,7 +77,7 @@ class TestWeekDay(object):
     def test_unicode(self):
         day = WeekDay(0)
         flexmock(day).should_receive('name').and_return(u'maanantaina')
-        assert six.text_type(day) == u'maanantaina'
+        assert str(day) == u'maanantaina'
 
     def test_str(self):
         day = WeekDay(0)
@@ -161,7 +160,7 @@ class TestWeekDays(object):
     def test_unicode(self):
         i18n.get_locale = lambda: i18n.babel.Locale('fi')
         days = WeekDays('1000100')
-        assert six.text_type(days) == u'maanantaina, perjantaina'
+        assert str(days) == u'maanantaina, perjantaina'
 
     def test_str(self):
         i18n.get_locale = lambda: i18n.babel.Locale('fi')

--- a/tests/primitives/test_weekdays.py
+++ b/tests/primitives/test_weekdays.py
@@ -63,25 +63,25 @@ class TestWeekDay(object):
 
     def test_get_name_returns_localized_week_day_name(self):
         day = WeekDay(0)
-        assert day.get_name() == u'maanantaina'
+        assert day.get_name() == 'maanantaina'
 
     def test_override_get_locale_as_class_method(self):
         day = WeekDay(0)
-        assert day.get_name() == u'maanantaina'
+        assert day.get_name() == 'maanantaina'
 
     def test_name_delegates_to_get_name(self):
         day = WeekDay(0)
-        flexmock(day).should_receive('get_name').and_return(u'maanantaina')
-        assert day.name == u'maanantaina'
+        flexmock(day).should_receive('get_name').and_return('maanantaina')
+        assert day.name == 'maanantaina'
 
     def test_unicode(self):
         day = WeekDay(0)
-        flexmock(day).should_receive('name').and_return(u'maanantaina')
-        assert str(day) == u'maanantaina'
+        flexmock(day).should_receive('name').and_return('maanantaina')
+        assert str(day) == 'maanantaina'
 
     def test_str(self):
         day = WeekDay(0)
-        flexmock(day).should_receive('name').and_return(u'maanantaina')
+        flexmock(day).should_receive('name').and_return('maanantaina')
         assert str(day) == 'maanantaina'
 
 
@@ -160,7 +160,7 @@ class TestWeekDays(object):
     def test_unicode(self):
         i18n.get_locale = lambda: i18n.babel.Locale('fi')
         days = WeekDays('1000100')
-        assert str(days) == u'maanantaina, perjantaina'
+        assert str(days) == 'maanantaina, perjantaina'
 
     def test_str(self):
         i18n.get_locale = lambda: i18n.babel.Locale('fi')

--- a/tests/primitives/test_weekdays.py
+++ b/tests/primitives/test_weekdays.py
@@ -12,7 +12,7 @@ def set_get_locale():
 
 @pytest.mark.skipif('i18n.babel is None')
 @pytest.mark.usefixtures('set_get_locale')
-class TestWeekDay(object):
+class TestWeekDay:
 
     def test_constructor_with_valid_index(self):
         day = WeekDay(1)
@@ -86,7 +86,7 @@ class TestWeekDay(object):
 
 
 @pytest.mark.skipif('i18n.babel is None')
-class TestWeekDays(object):
+class TestWeekDays:
     def test_constructor_with_valid_bit_string(self):
         days = WeekDays('1000100')
         assert days._days == set([WeekDay(0), WeekDay(4)])

--- a/tests/relationships/test_select_correlated_expression.py
+++ b/tests/relationships/test_select_correlated_expression.py
@@ -248,7 +248,7 @@ def dataset(
 
 
 @pytest.mark.usefixtures('dataset', 'postgresql_dsn')
-class TestSelectCorrelatedExpression(object):
+class TestSelectCorrelatedExpression:
     @pytest.mark.parametrize(
         ('model_key', 'related_model_key', 'path', 'result'),
         (

--- a/tests/test_asserts.py
+++ b/tests/test_asserts.py
@@ -48,7 +48,7 @@ def user(User, session):
 
 
 @pytest.mark.usefixtures('postgresql_dsn')
-class TestAssertMaxLengthWithArray(object):
+class TestAssertMaxLengthWithArray:
 
     def test_with_max_length(self, user):
         assert_max_length(user, 'fav_numbers', 8)
@@ -68,7 +68,7 @@ class TestAssertMaxLengthWithArray(object):
 
 
 @pytest.mark.usefixtures('postgresql_dsn')
-class TestAssertNonNullable(object):
+class TestAssertNonNullable:
 
     def test_non_nullable_column(self, user):
         # Test everything twice so that session gets rolled back properly
@@ -83,7 +83,7 @@ class TestAssertNonNullable(object):
 
 
 @pytest.mark.usefixtures('postgresql_dsn')
-class TestAssertNullable(object):
+class TestAssertNullable:
 
     def test_nullable_column(self, user):
         assert_nullable(user, 'name')
@@ -97,7 +97,7 @@ class TestAssertNullable(object):
 
 
 @pytest.mark.usefixtures('postgresql_dsn')
-class TestAssertMaxLength(object):
+class TestAssertMaxLength:
 
     def test_with_max_length(self, user):
         assert_max_length(user, 'name', 20)
@@ -121,7 +121,7 @@ class TestAssertMaxLength(object):
 
 
 @pytest.mark.usefixtures('postgresql_dsn')
-class TestAssertMinValue(object):
+class TestAssertMinValue:
 
     def test_with_min_value(self, user):
         assert_min_value(user, 'age', 0)
@@ -141,7 +141,7 @@ class TestAssertMinValue(object):
 
 
 @pytest.mark.usefixtures('postgresql_dsn')
-class TestAssertMaxValue(object):
+class TestAssertMaxValue:
 
     def test_with_min_value(self, user):
         assert_max_value(user, 'age', 150)

--- a/tests/test_auto_delete_orphans.py
+++ b/tests/test_auto_delete_orphans.py
@@ -70,7 +70,7 @@ def EntryWithoutTagsBackref(Base, Tag, tagging_tbl):
     return EntryWithoutTagsBackref
 
 
-class TestAutoDeleteOrphans(object):
+class TestAutoDeleteOrphans:
 
     @pytest.fixture
     def init_models(self, Entry, Tag):
@@ -101,7 +101,7 @@ class TestAutoDeleteOrphans(object):
         assert session.query(Tag).count() == 2
 
 
-class TestAutoDeleteOrphansWithoutBackref(object):
+class TestAutoDeleteOrphansWithoutBackref:
 
     @pytest.fixture
     def init_models(self, EntryWithoutTagsBackref, Tag):

--- a/tests/test_case_insensitive_comparator.py
+++ b/tests/test_case_insensitive_comparator.py
@@ -21,7 +21,7 @@ def init_models(User):
     pass
 
 
-class TestCaseInsensitiveComparator(object):
+class TestCaseInsensitiveComparator:
 
     def test_supports_equals(self, session, User):
         query = (

--- a/tests/test_case_insensitive_comparator.py
+++ b/tests/test_case_insensitive_comparator.py
@@ -26,7 +26,7 @@ class TestCaseInsensitiveComparator(object):
     def test_supports_equals(self, session, User):
         query = (
             session.query(User)
-            .filter(User.email == u'email@example.com')
+            .filter(User.email == 'email@example.com')
         )
 
         assert 'user.email = lower(?)' in str(query)
@@ -34,7 +34,7 @@ class TestCaseInsensitiveComparator(object):
     def test_supports_in_(self, session, User):
         query = (
             session.query(User)
-            .filter(User.email.in_([u'email@example.com', u'a']))
+            .filter(User.email.in_(['email@example.com', 'a']))
         )
         assert (
             'user.email IN (lower(?), lower(?))'
@@ -44,7 +44,7 @@ class TestCaseInsensitiveComparator(object):
     def test_supports_notin_(self, session, User):
         query = (
             session.query(User)
-            .filter(User.email.notin_([u'email@example.com', u'a']))
+            .filter(User.email.notin_(['email@example.com', 'a']))
         )
         assert (
             'user.email NOT IN ('

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -26,7 +26,7 @@ def Article(Base):
     return Article
 
 
-class TestAsterisk(object):
+class TestAsterisk:
     def test_with_table_object(self):
         Base = sa.ext.declarative.declarative_base()
 
@@ -48,7 +48,7 @@ class TestAsterisk(object):
         )) == '"user".*'
 
 
-class TestRowToJson(object):
+class TestRowToJson:
     def test_compiler_with_default_dialect(self):
         assert str(row_to_json(sa.text('article.*'))) == (
             'row_to_json(article.*)'

--- a/tests/test_instrumented_list.py
+++ b/tests/test_instrumented_list.py
@@ -1,4 +1,4 @@
-class TestInstrumentedList(object):
+class TestInstrumentedList:
     def test_any_returns_true_if_member_has_attr_defined(
         self,
         Category,

--- a/tests/test_instrumented_list.py
+++ b/tests/test_instrumented_list.py
@@ -6,7 +6,7 @@ class TestInstrumentedList(object):
     ):
         category = Category()
         category.articles.append(Article())
-        category.articles.append(Article(name=u'some name'))
+        category.articles.append(Article(name='some name'))
         assert category.articles.any('name')
 
     def test_any_returns_false_if_no_member_has_attr_defined(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,7 +6,7 @@ import sqlalchemy as sa
 from sqlalchemy_utils import generic_repr, Timestamp
 
 
-class TestTimestamp(object):
+class TestTimestamp:
     @pytest.fixture
     def Article(self, Base):
         class Article(Base, Timestamp):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,3 @@
-import sys
 from datetime import datetime
 
 import pytest
@@ -13,7 +12,7 @@ class TestTimestamp(object):
         class Article(Base, Timestamp):
             __tablename__ = 'article'
             id = sa.Column(sa.Integer, primary_key=True)
-            name = sa.Column(sa.Unicode(255), default=u'Some article')
+            name = sa.Column(sa.Unicode(255), default='Some article')
         return Article
 
     def test_created(self, session, Article):
@@ -32,7 +31,7 @@ class TestTimestamp(object):
         session.commit()
 
         then = datetime.utcnow()
-        article.name = u"Something"
+        article.name = "Something"
 
         session.commit()
 
@@ -45,19 +44,14 @@ class TestGenericRepr:
         class Article(Base):
             __tablename__ = 'article'
             id = sa.Column(sa.Integer, primary_key=True)
-            name = sa.Column(sa.Unicode(255), default=u'Some article')
+            name = sa.Column(sa.Unicode(255), default='Some article')
         return Article
 
     def test_repr(self, Article):
         """Representation of a basic model."""
         Article = generic_repr(Article)
-        article = Article(id=1, name=u'Foo')
-        if sys.version_info[0] == 2:
-            expected_repr = u'Article(id=1, name=u\'Foo\')'
-        elif sys.version_info[0] == 3:
-            expected_repr = u'Article(id=1, name=\'Foo\')'
-        else:
-            raise AssertionError
+        article = Article(id=1, name='Foo')
+        expected_repr = "Article(id=1, name='Foo')"
         actual_repr = repr(article)
 
         assert actual_repr == expected_repr
@@ -65,8 +59,8 @@ class TestGenericRepr:
     def test_repr_partial(self, Article):
         """Representation of a basic model with selected fields."""
         Article = generic_repr('id')(Article)
-        article = Article(id=1, name=u'Foo')
-        expected_repr = u'Article(id=1)'
+        article = Article(id=1, name='Foo')
+        expected_repr = 'Article(id=1)'
         actual_repr = repr(article)
 
         assert actual_repr == expected_repr
@@ -77,12 +71,12 @@ class TestGenericRepr:
         instead represents them as "<not loaded>".
         """
         Article = generic_repr(Article)
-        article = Article(name=u'Foo')
+        article = Article(name='Foo')
         session.add(article)
         session.commit()
 
         article = session.query(Article).options(sa.orm.defer('name')).one()
         actual_repr = repr(article)
 
-        expected_repr = u'Article(id={}, name=<not loaded>)'.format(article.id)
+        expected_repr = 'Article(id={}, name=<not loaded>)'.format(article.id)
         assert actual_repr == expected_repr

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -1,5 +1,4 @@
 import pytest
-import six
 import sqlalchemy as sa
 from sqlalchemy.util.langhelpers import symbol
 
@@ -166,7 +165,7 @@ class TestPath(object):
         assert Path('s.s2.s3').index('s2') == 1
 
     def test_unicode(self):
-        assert six.text_type(Path('s.s2')) == u's.s2'
+        assert str(Path('s.s2')) == u's.s2'
 
     def test_getitem_with_slice(self):
         path = Path('s.s2.s3')

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -165,7 +165,7 @@ class TestPath(object):
         assert Path('s.s2.s3').index('s2') == 1
 
     def test_unicode(self):
-        assert str(Path('s.s2')) == u's.s2'
+        assert str(Path('s.s2')) == 's.s2'
 
     def test_getitem_with_slice(self):
         path = Path('s.s2.s3')

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -47,7 +47,7 @@ def SubSection(Base, Section):
     return SubSection
 
 
-class TestAttrPath(object):
+class TestAttrPath:
 
     @pytest.fixture
     def init_models(self, Document, Section, SubSection):
@@ -124,7 +124,7 @@ class TestAttrPath(object):
         )
 
 
-class TestPath(object):
+class TestPath:
     def test_init(self):
         path = Path('attr.attr2')
         assert path.path == 'attr.attr2'

--- a/tests/test_proxy_dict.py
+++ b/tests/test_proxy_dict.py
@@ -51,7 +51,7 @@ def init_models(ArticleTranslation, Article):
     pass
 
 
-class TestProxyDict(object):
+class TestProxyDict:
 
     def test_access_key_for_pending_parent(self, session, Article):
         article = Article()

--- a/tests/test_proxy_dict.py
+++ b/tests/test_proxy_dict.py
@@ -86,7 +86,7 @@ class TestProxyDict(object):
         article.translations['en']
         article.translations['en'] = ArticleTranslation(
             locale='en',
-            name=u'something'
+            name='something'
         )
         article.translations['en']
 

--- a/tests/test_query_chain.py
+++ b/tests/test_query_chain.py
@@ -68,7 +68,7 @@ def chain(session, users, articles, posts, User, Article, BlogPost):
     )
 
 
-class TestQueryChain(object):
+class TestQueryChain:
 
     def test_iter(self, chain):
         assert len(list(chain)) == 9

--- a/tests/test_translation_hybrid.py
+++ b/tests/test_translation_hybrid.py
@@ -30,7 +30,7 @@ def init_models(City):
 
 @pytest.mark.usefixtures('postgresql_dsn')
 @pytest.mark.skipif('i18n.babel is None')
-class TestTranslationHybrid(object):
+class TestTranslationHybrid:
 
     def test_using_hybrid_as_constructor(self, City):
         city = City(name='Helsinki')
@@ -111,7 +111,7 @@ class TestTranslationHybrid(object):
         )
 
     def test_locales_casted_only_in_compilation_phase(self, Base):
-        class LocaleGetter(object):
+        class LocaleGetter:
             def current_locale(self):
                 return lambda obj: obj.locale
 

--- a/tests/types/encrypted/test_padding.py
+++ b/tests/types/encrypted/test_padding.py
@@ -6,7 +6,7 @@ from sqlalchemy_utils.types.encrypted.padding import (
 )
 
 
-class TestPkcs5Padding(object):
+class TestPkcs5Padding:
     def setup_method(self):
         self.BLOCK_SIZE = 8
         self.padder = PKCS5Padding(self.BLOCK_SIZE)

--- a/tests/types/test_arrow.py
+++ b/tests/types/test_arrow.py
@@ -24,7 +24,7 @@ def init_models(Article):
 
 
 @pytest.mark.skipif('arrow.arrow is None')
-class TestArrowDateTimeType(object):
+class TestArrowDateTimeType:
     def test_parameter_processing(self, session, Article):
         article = Article(
             created_at=arrow.arrow.get(datetime(2000, 11, 1))

--- a/tests/types/test_choice.py
+++ b/tests/types/test_choice.py
@@ -6,7 +6,7 @@ from sqlalchemy_utils import Choice, ChoiceType, ImproperlyConfigured
 from sqlalchemy_utils.types.choice import Enum
 
 
-class TestChoice(object):
+class TestChoice:
     def test_equality_operator(self):
         assert Choice(1, 1) == 1
         assert 1 == Choice(1, 1)
@@ -20,7 +20,7 @@ class TestChoice(object):
         assert hash(Choice(1, 1)) == hash(1)
 
 
-class TestChoiceType(object):
+class TestChoiceType:
     @pytest.fixture
     def User(self, Base):
         class User(Base):
@@ -86,14 +86,14 @@ class TestChoiceType(object):
         session.execute(query)
 
 
-class TestChoiceTypeWithCustomUnderlyingType(object):
+class TestChoiceTypeWithCustomUnderlyingType:
     def test_init_type(self):
         type_ = ChoiceType([(1, 'something')], impl=sa.Integer)
         assert type_.impl == sa.Integer
 
 
 @pytest.mark.skipif('Enum is None')
-class TestEnumType(object):
+class TestEnumType:
 
     @pytest.fixture
     def OrderStatus(self):

--- a/tests/types/test_choice.py
+++ b/tests/types/test_choice.py
@@ -48,31 +48,31 @@ class TestChoiceType(object):
 
     def test_string_processing(self, session, User):
         flexmock(ChoiceType).should_receive('_coerce').and_return(
-            u'admin'
+            'admin'
         )
         user = User(
-            type=u'admin'
+            type='admin'
         )
 
         session.add(user)
         session.commit()
 
         user = session.query(User).first()
-        assert user.type.value == u'Admin'
+        assert user.type.value == 'Admin'
 
     def test_parameter_processing(self, session, User):
         user = User(
-            type=u'admin'
+            type='admin'
         )
 
         session.add(user)
         session.commit()
 
         user = session.query(User).first()
-        assert user.type.value == u'Admin'
+        assert user.type.value == 'Admin'
 
     def test_scalar_attributes_get_coerced_to_objects(self, User):
-        user = User(type=u'admin')
+        user = User(type='admin')
 
         assert isinstance(user.type, Choice)
 
@@ -88,7 +88,7 @@ class TestChoiceType(object):
 
 class TestChoiceTypeWithCustomUnderlyingType(object):
     def test_init_type(self):
-        type_ = ChoiceType([(1, u'something')], impl=sa.Integer)
+        type_ = ChoiceType([(1, 'something')], impl=sa.Integer)
         assert type_.impl == sa.Integer
 
 

--- a/tests/types/test_color.py
+++ b/tests/types/test_color.py
@@ -28,7 +28,7 @@ class TestColorType(object):
         from colour import Color
 
         flexmock(ColorType).should_receive('_coerce').and_return(
-            u'white'
+            'white'
         )
         document = Document(
             bg_color='white'
@@ -38,17 +38,17 @@ class TestColorType(object):
         session.commit()
 
         document = session.query(Document).first()
-        assert document.bg_color.hex == Color(u'white').hex
+        assert document.bg_color.hex == Color('white').hex
 
     def test_color_parameter_processing(self, session, Document):
         from colour import Color
 
-        document = Document(bg_color=Color(u'white'))
+        document = Document(bg_color=Color('white'))
         session.add(document)
         session.commit()
 
         document = session.query(Document).first()
-        assert document.bg_color.hex == Color(u'white').hex
+        assert document.bg_color.hex == Color('white').hex
 
     def test_scalar_attributes_get_coerced_to_objects(self, Document):
         from colour import Color

--- a/tests/types/test_color.py
+++ b/tests/types/test_color.py
@@ -23,7 +23,7 @@ def init_models(Document):
 
 
 @pytest.mark.skipif('types.color.python_colour_type is None')
-class TestColorType(object):
+class TestColorType:
     def test_string_parameter_processing(self, session, Document):
         from colour import Color
 

--- a/tests/types/test_composite.py
+++ b/tests/types/test_composite.py
@@ -19,7 +19,7 @@ from sqlalchemy_utils.types.range import intervals
 
 
 @pytest.mark.usefixtures('postgresql_dsn')
-class TestCompositeTypeWithRegularTypes(object):
+class TestCompositeTypeWithRegularTypes:
 
     @pytest.fixture
     def Account(self, Base):
@@ -102,7 +102,7 @@ class TestCompositeTypeWithRegularTypes(object):
 
 @pytest.mark.skipif('i18n.babel is None')
 @pytest.mark.usefixtures('postgresql_dsn')
-class TestCompositeTypeWithTypeDecorators(object):
+class TestCompositeTypeWithTypeDecorators:
 
     @pytest.fixture
     def Account(self, Base):
@@ -164,7 +164,7 @@ class TestCompositeTypeWithTypeDecorators(object):
 
 @pytest.mark.skipif('i18n.babel is None')
 @pytest.mark.usefixtures('postgresql_dsn')
-class TestCompositeTypeInsideArray(object):
+class TestCompositeTypeInsideArray:
 
     @pytest.fixture
     def type_(self):
@@ -228,7 +228,7 @@ class TestCompositeTypeInsideArray(object):
 
 @pytest.mark.skipif('intervals is None')
 @pytest.mark.usefixtures('postgresql_dsn')
-class TestCompositeTypeWithRangeTypeInsideArray(object):
+class TestCompositeTypeWithRangeTypeInsideArray:
 
     @pytest.fixture
     def type_(self):
@@ -347,7 +347,7 @@ class TestCompositeTypeWithRangeTypeInsideArray(object):
 
 
 @pytest.mark.usefixtures('postgresql_dsn')
-class TestCompositeTypeWhenTypeAlreadyExistsInDatabase(object):
+class TestCompositeTypeWhenTypeAlreadyExistsInDatabase:
 
     @pytest.fixture
     def Account(self, Base):
@@ -411,7 +411,7 @@ class TestCompositeTypeWhenTypeAlreadyExistsInDatabase(object):
 
 
 @pytest.mark.usefixtures('postgresql_dsn')
-class TestCompositeTypeWithMixedCase(object):
+class TestCompositeTypeWithMixedCase:
 
     @pytest.fixture
     def Account(self, Base):

--- a/tests/types/test_composite.py
+++ b/tests/types/test_composite.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import pytest
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import ARRAY

--- a/tests/types/test_composite.py
+++ b/tests/types/test_composite.py
@@ -56,14 +56,14 @@ class TestCompositeTypeWithRegularTypes(object):
 
     def test_non_ascii_chars(self, session, Account):
         account = Account(
-            balance=(u'ääöö', 15)
+            balance=('ääöö', 15)
         )
 
         session.add(account)
         session.commit()
 
         account = session.query(Account).first()
-        assert account.balance.currency == u'ääöö'
+        assert account.balance.currency == 'ääöö'
         assert account.balance.amount == 15
 
     def test_dict_input(self, session, Account):

--- a/tests/types/test_country.py
+++ b/tests/types/test_country.py
@@ -26,14 +26,14 @@ class TestCountryType(object):
 
     def test_parameter_processing(self, session, User):
         user = User(
-            country=Country(u'FI')
+            country=Country('FI')
         )
 
         session.add(user)
         session.commit()
 
         user = session.query(User).first()
-        assert user.country.name == u'Finland'
+        assert user.country.name == 'Finland'
 
     def test_scalar_attributes_get_coerced_to_objects(self, User):
         user = User(country='FI')

--- a/tests/types/test_country.py
+++ b/tests/types/test_country.py
@@ -22,7 +22,7 @@ def init_models(User):
 
 
 @pytest.mark.skipif('i18n.babel is None')
-class TestCountryType(object):
+class TestCountryType:
 
     def test_parameter_processing(self, session, User):
         user = User(

--- a/tests/types/test_currency.py
+++ b/tests/types/test_currency.py
@@ -38,7 +38,7 @@ class TestCurrencyType(object):
         session.commit()
 
         user = session.query(User).first()
-        assert user.currency.name == u'US Dollar'
+        assert user.currency.name == 'US Dollar'
 
     def test_scalar_attributes_get_coerced_to_objects(
         self,

--- a/tests/types/test_currency.py
+++ b/tests/types/test_currency.py
@@ -28,7 +28,7 @@ def init_models(User):
 
 
 @pytest.mark.skipif('i18n.babel is None')
-class TestCurrencyType(object):
+class TestCurrencyType:
     def test_parameter_processing(self, session, User, set_get_locale):
         user = User(
             currency=Currency('USD')

--- a/tests/types/test_email.py
+++ b/tests/types/test_email.py
@@ -17,7 +17,7 @@ def User(Base):
     return User
 
 
-class TestEmailType(object):
+class TestEmailType:
     def test_saves_email_as_lowercased(self, session, User):
         user = User(email='Someone@example.com')
 

--- a/tests/types/test_email.py
+++ b/tests/types/test_email.py
@@ -19,13 +19,13 @@ def User(Base):
 
 class TestEmailType(object):
     def test_saves_email_as_lowercased(self, session, User):
-        user = User(email=u'Someone@example.com')
+        user = User(email='Someone@example.com')
 
         session.add(user)
         session.commit()
 
         user = session.query(User).first()
-        assert user.email == u'someone@example.com'
+        assert user.email == 'someone@example.com'
 
     def test_literal_param(self, session, User):
         clause = User.email == 'Someone@example.com'

--- a/tests/types/test_encrypted.py
+++ b/tests/types/test_encrypted.py
@@ -115,17 +115,17 @@ def test_key():
 
 @pytest.fixture
 def user_name():
-    return u'someone'
+    return 'someone'
 
 
 @pytest.fixture
 def user_phone():
-    return u'(555) 555-5555'
+    return '(555) 555-5555'
 
 
 @pytest.fixture
 def user_color():
-    return u'#fff'
+    return '#fff'
 
 
 @pytest.fixture
@@ -299,14 +299,14 @@ class EncryptedTypeTestCase(object):
     def test_lookup_key(self, session, Team):
         # Add teams
         self._team_key = 'one'
-        team = Team(key=self._team_key, name=u'One')
+        team = Team(key=self._team_key, name='One')
         session.add(team)
         session.commit()
         team_1_id = team.id
 
         self._team_key = 'two'
         team = Team(key=self._team_key)
-        team.name = u'Two'
+        team.name = 'Two'
         session.add(team)
         session.commit()
         team_2_id = team.id
@@ -318,7 +318,7 @@ class EncryptedTypeTestCase(object):
 
         team = session.query(Team).get(team_1_id)
 
-        assert team.name == u'One'
+        assert team.name == 'One'
 
         session.expunge_all()
 
@@ -328,7 +328,7 @@ class EncryptedTypeTestCase(object):
 
         team = session.query(Team).get(team_2_id)
 
-        assert team.name == u'Two'
+        assert team.name == 'Two'
 
         session.expunge_all()
 
@@ -375,13 +375,13 @@ class TestAesEncryptedTypeTestcaseWithNaivePadding(AesEncryptedTypeTestCase):
 
     def test_decrypt_raises_value_error_with_invalid_key(self, session, Team):
         self._team_key = 'one'
-        team = Team(key=self._team_key, name=u'One')
+        team = Team(key=self._team_key, name='One')
         session.add(team)
         session.commit()
 
         self._team_key = 'notone'
         with pytest.raises(ValueError):
-            assert team.name == u'One'
+            assert team.name == 'One'
 
 
 class TestFernetEncryptedTypeTestCase(EncryptedTypeTestCase):

--- a/tests/types/test_encrypted.py
+++ b/tests/types/test_encrypted.py
@@ -241,7 +241,7 @@ def date_simple():
 
 
 @pytest.mark.skipif('cryptography is None')
-class EncryptedTypeTestCase(object):
+class EncryptedTypeTestCase:
 
     @pytest.fixture
     def Team(self, Base, encryption_engine, padding_mechanism):
@@ -459,7 +459,7 @@ class TestDatetimeHandler:
 
 
 @pytest.mark.skipif('cryptography is None')
-class TestAesGcmEngine(object):
+class TestAesGcmEngine:
     KEY = b'0123456789ABCDEF'
 
     def setup_method(self):

--- a/tests/types/test_enriched_date_pendulum.py
+++ b/tests/types/test_enriched_date_pendulum.py
@@ -30,7 +30,7 @@ def init_models(User):
 
 
 @pytest.mark.skipif('pendulum_date.pendulum is None')
-class TestPendulumDateType(object):
+class TestPendulumDateType:
     def test_parameter_processing(self, session, User):
         user = User(
             birthday=pendulum_date.pendulum.date(1995, 7, 11)

--- a/tests/types/test_enriched_date_pendulum.py
+++ b/tests/types/test_enriched_date_pendulum.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from datetime import date
 
 import pytest

--- a/tests/types/test_enriched_datetime_arrow.py
+++ b/tests/types/test_enriched_datetime_arrow.py
@@ -34,7 +34,7 @@ def init_models(Article):
 
 
 @pytest.mark.skipif('arrow_datetime.arrow is None')
-class TestArrowDateTimeType(object):
+class TestArrowDateTimeType:
     def test_parameter_processing(self, session, Article):
         article = Article(
             created_at=arrow_datetime.arrow.get(datetime(2000, 11, 1))

--- a/tests/types/test_enriched_datetime_pendulum.py
+++ b/tests/types/test_enriched_datetime_pendulum.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from datetime import datetime
 
 import pytest

--- a/tests/types/test_enriched_datetime_pendulum.py
+++ b/tests/types/test_enriched_datetime_pendulum.py
@@ -29,7 +29,7 @@ def init_models(User):
 
 
 @pytest.mark.skipif('pendulum_datetime.pendulum is None')
-class TestPendulumDateTimeType(object):
+class TestPendulumDateTimeType:
 
     def test_parameter_processing(self, session, User):
         user = User(

--- a/tests/types/test_int_range.py
+++ b/tests/types/test_int_range.py
@@ -44,7 +44,7 @@ def create_building(session, Building):
 
 
 @pytest.mark.skipif('intervals is None')
-class NumberRangeTestCase(object):
+class NumberRangeTestCase:
 
     def test_nullify_range(self, create_building):
         building = create_building(None)

--- a/tests/types/test_ip_address.py
+++ b/tests/types/test_ip_address.py
@@ -25,14 +25,14 @@ def init_models(Visitor):
 class TestIPAddressType(object):
     def test_parameter_processing(self, session, Visitor):
         visitor = Visitor(
-            ip_address=u'111.111.111.111'
+            ip_address='111.111.111.111'
         )
 
         session.add(visitor)
         session.commit()
 
         visitor = session.query(Visitor).first()
-        assert str(visitor.ip_address) == u'111.111.111.111'
+        assert str(visitor.ip_address) == '111.111.111.111'
 
     def test_compilation(self, Visitor, session):
         query = sa.select([Visitor.ip_address])

--- a/tests/types/test_ip_address.py
+++ b/tests/types/test_ip_address.py
@@ -1,5 +1,4 @@
 import pytest
-import six
 import sqlalchemy as sa
 
 from sqlalchemy_utils.types import ip_address
@@ -33,7 +32,7 @@ class TestIPAddressType(object):
         session.commit()
 
         visitor = session.query(Visitor).first()
-        assert six.text_type(visitor.ip_address) == u'111.111.111.111'
+        assert str(visitor.ip_address) == u'111.111.111.111'
 
     def test_compilation(self, Visitor, session):
         query = sa.select([Visitor.ip_address])

--- a/tests/types/test_ip_address.py
+++ b/tests/types/test_ip_address.py
@@ -22,7 +22,7 @@ def init_models(Visitor):
 
 
 @pytest.mark.skipif('ip_address.ip_address is None')
-class TestIPAddressType(object):
+class TestIPAddressType:
     def test_parameter_processing(self, session, Visitor):
         visitor = Visitor(
             ip_address='111.111.111.111'

--- a/tests/types/test_json.py
+++ b/tests/types/test_json.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import pytest
 import sqlalchemy as sa
 import sqlalchemy.orm as sa_orm

--- a/tests/types/test_json.py
+++ b/tests/types/test_json.py
@@ -66,14 +66,14 @@ class JSONTestCase(object):
 
     def test_non_ascii_chars(self, session, Document):
         document = Document(
-            json={'something': u'äääööö'}
+            json={'something': 'äääööö'}
         )
 
         session.add(document)
         session.commit()
 
         document = session.query(Document).first()
-        assert document.json == {'something': u'äääööö'}
+        assert document.json == {'something': 'äääööö'}
 
     def test_compilation(self, Document, session):
         query = sa.select([Document.json])

--- a/tests/types/test_json.py
+++ b/tests/types/test_json.py
@@ -41,7 +41,7 @@ def init_models(Document):
     pass
 
 
-class JSONTestCase(object):
+class JSONTestCase:
     def test_list(self, session, Document):
         document = Document(
             json=[1, 2, 3]

--- a/tests/types/test_locale.py
+++ b/tests/types/test_locale.py
@@ -25,7 +25,7 @@ def init_models(User):
 class TestLocaleType(object):
     def test_parameter_processing(self, session, User):
         user = User(
-            locale=locale.babel.Locale(u'fi')
+            locale=locale.babel.Locale('fi')
         )
 
         session.add(user)
@@ -34,7 +34,7 @@ class TestLocaleType(object):
         user = session.query(User).first()
 
     def test_territory_parsing(self, session, User):
-        ko_kr = locale.babel.Locale(u'ko', territory=u'KR')
+        ko_kr = locale.babel.Locale('ko', territory='KR')
         user = User(locale=ko_kr)
         session.add(user)
         session.commit()
@@ -44,7 +44,7 @@ class TestLocaleType(object):
     def test_coerce_territory_parsing(self, User):
         user = User()
         user.locale = 'ko_KR'
-        assert user.locale == locale.babel.Locale(u'ko', territory=u'KR')
+        assert user.locale == locale.babel.Locale('ko', territory='KR')
 
     def test_scalar_attributes_get_coerced_to_objects(self, User):
         user = User(locale='en_US')
@@ -53,7 +53,7 @@ class TestLocaleType(object):
 
     def test_unknown_locale_throws_exception(self, User):
         with pytest.raises(locale.babel.UnknownLocaleError):
-            User(locale=u'unknown')
+            User(locale='unknown')
 
     def test_literal_param(self, session, User):
         clause = User.locale == 'en_US'

--- a/tests/types/test_locale.py
+++ b/tests/types/test_locale.py
@@ -22,7 +22,7 @@ def init_models(User):
 
 
 @pytest.mark.skipif('locale.babel is None')
-class TestLocaleType(object):
+class TestLocaleType:
     def test_parameter_processing(self, session, User):
         user = User(
             locale=locale.babel.Locale('fi')

--- a/tests/types/test_ltree.py
+++ b/tests/types/test_ltree.py
@@ -21,7 +21,7 @@ def init_models(Section, connection):
 
 
 @pytest.mark.usefixtures('postgresql_dsn')
-class TestLTREE(object):
+class TestLTREE:
     def test_saves_path(self, session, Section):
         section = Section(path='1.1.2')
 

--- a/tests/types/test_numeric_range.py
+++ b/tests/types/test_numeric_range.py
@@ -28,7 +28,7 @@ def create_car(session, Car):
 
 
 @pytest.mark.skipif('intervals is None')
-class NumericRangeTestCase(object):
+class NumericRangeTestCase:
 
     @pytest.fixture
     def Car(self, Base):
@@ -125,7 +125,7 @@ class TestNumericRangeOnPostgres(NumericRangeTestCase):
 
 
 @pytest.mark.skipif('intervals is None')
-class TestNumericRangeWithStep(object):
+class TestNumericRangeWithStep:
     @pytest.fixture
     def Car(self, Base):
         class Car(Base):

--- a/tests/types/test_password.py
+++ b/tests/types/test_password.py
@@ -55,7 +55,7 @@ def onload_callback(schemes, deprecated):
 
 
 @pytest.mark.skipif('types.password.passlib is None')
-class TestPasswordType(object):
+class TestPasswordType:
     @pytest.mark.parametrize('dialect_module,impl', [
         (sqlalchemy.dialects.sqlite, sa.dialects.sqlite.BLOB),
         (sqlalchemy.dialects.postgresql, sa.dialects.postgresql.BYTEA),

--- a/tests/types/test_scalar_list.py
+++ b/tests/types/test_scalar_list.py
@@ -1,5 +1,4 @@
 import pytest
-import six
 import sqlalchemy as sa
 
 from sqlalchemy_utils import ScalarListType
@@ -42,7 +41,7 @@ class TestScalarUnicodeList(object):
         class User(Base):
             __tablename__ = 'user'
             id = sa.Column(sa.Integer, primary_key=True)
-            some_list = sa.Column(ScalarListType(six.text_type))
+            some_list = sa.Column(ScalarListType(str))
 
             def __repr__(self):
                 return 'User(%r)' % self.id

--- a/tests/types/test_scalar_list.py
+++ b/tests/types/test_scalar_list.py
@@ -4,7 +4,7 @@ import sqlalchemy as sa
 from sqlalchemy_utils import ScalarListType
 
 
-class TestScalarIntegerList(object):
+class TestScalarIntegerList:
 
     @pytest.fixture
     def User(self, Base):
@@ -34,7 +34,7 @@ class TestScalarIntegerList(object):
         assert user.some_list == [1, 2, 3, 4]
 
 
-class TestScalarUnicodeList(object):
+class TestScalarUnicodeList:
 
     @pytest.fixture
     def User(self, Base):

--- a/tests/types/test_scalar_list.py
+++ b/tests/types/test_scalar_list.py
@@ -58,7 +58,7 @@ class TestScalarUnicodeList(object):
         User
     ):
         user = User(
-            some_list=[u',']
+            some_list=[',']
         )
 
         session.add(user)
@@ -72,14 +72,14 @@ class TestScalarUnicodeList(object):
 
     def test_save_unicode_list(self, session, User):
         user = User(
-            some_list=[u'1', u'2', u'3', u'4']
+            some_list=['1', '2', '3', '4']
         )
 
         session.add(user)
         session.commit()
 
         user = session.query(User).first()
-        assert user.some_list == [u'1', u'2', u'3', u'4']
+        assert user.some_list == ['1', '2', '3', '4']
 
     def test_save_and_retrieve_empty_list(self, session, User):
         user = User(

--- a/tests/types/test_timezone.py
+++ b/tests/types/test_timezone.py
@@ -39,22 +39,22 @@ def init_models(Visitor):
 class TestTimezoneType:
     def test_parameter_processing(self, session, Visitor):
         visitor = Visitor(
-            timezone_dateutil=u'America/Los_Angeles',
-            timezone_pytz=u'America/Los_Angeles',
-            timezone_zoneinfo=u'America/Los_Angeles'
+            timezone_dateutil='America/Los_Angeles',
+            timezone_pytz='America/Los_Angeles',
+            timezone_zoneinfo='America/Los_Angeles'
         )
 
         session.add(visitor)
         session.commit()
 
         visitor_dateutil = session.query(Visitor).filter_by(
-            timezone_dateutil=u'America/Los_Angeles'
+            timezone_dateutil='America/Los_Angeles'
         ).first()
         visitor_pytz = session.query(Visitor).filter_by(
-            timezone_pytz=u'America/Los_Angeles'
+            timezone_pytz='America/Los_Angeles'
         ).first()
         visitor_zoneinfo = session.query(Visitor).filter_by(
-            timezone_zoneinfo=u'America/Los_Angeles'
+            timezone_zoneinfo='America/Los_Angeles'
         ).first()
 
         assert visitor_dateutil is not None

--- a/tests/types/test_tsvector.py
+++ b/tests/types/test_tsvector.py
@@ -47,7 +47,7 @@ class TestTSVector:
         assert type_.options['regconfig'] == 'pg_catalog.simple'
 
     def test_match(self, connection, User):
-        expr = User.search_index.match(u'something')
+        expr = User.search_index.match('something')
         assert str(expr.compile(connection)) == (
             '''"user".search_index @@ to_tsquery('pg_catalog.finnish', '''
             '''%(search_index_1)s)'''
@@ -68,7 +68,7 @@ class TestTSVector:
 
     def test_match_with_catalog(self, connection, User):
         expr = User.search_index.match(
-            u'something',
+            'something',
             postgresql_regconfig='pg_catalog.simple'
         )
         assert str(expr.compile(connection)) == (

--- a/tests/types/test_url.py
+++ b/tests/types/test_url.py
@@ -22,7 +22,7 @@ def init_models(User):
 
 
 @pytest.mark.skipif('url.furl is None')
-class TestURLType(object):
+class TestURLType:
     def test_color_parameter_processing(self, session, User):
         user = User(
             website=url.furl('www.example.com')

--- a/tests/types/test_url.py
+++ b/tests/types/test_url.py
@@ -25,7 +25,7 @@ def init_models(User):
 class TestURLType(object):
     def test_color_parameter_processing(self, session, User):
         user = User(
-            website=url.furl(u'www.example.com')
+            website=url.furl('www.example.com')
         )
 
         session.add(user)
@@ -35,7 +35,7 @@ class TestURLType(object):
         assert isinstance(user.website, url.furl)
 
     def test_scalar_attributes_get_coerced_to_objects(self, User):
-        user = User(website=u'www.example.com')
+        user = User(website='www.example.com')
 
         assert isinstance(user.website, url.furl)
 

--- a/tests/types/test_uuid.py
+++ b/tests/types/test_uuid.py
@@ -23,7 +23,7 @@ def init_models(User):
     pass
 
 
-class TestUUIDType(object):
+class TestUUIDType:
     def test_repr(self):
         plain = UUIDType()
         assert repr(plain) == 'UUIDType()'

--- a/tests/types/test_weekdays.py
+++ b/tests/types/test_weekdays.py
@@ -31,7 +31,7 @@ def set_get_locale():
 
 @pytest.mark.usefixtures('set_get_locale')
 @pytest.mark.skipif('i18n.babel is None')
-class WeekDaysTypeTestCase(object):
+class WeekDaysTypeTestCase:
     def test_color_parameter_processing(self, session, Schedule):
         schedule = Schedule(
             working_days=b'0001111'

--- a/tests/types/test_weekdays.py
+++ b/tests/types/test_weekdays.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import pytest
 import sqlalchemy as sa
 


### PR DESCRIPTION
This patch:

* Removes the six package as a dependency
* Replaces u-string literals (like `u"abc"`) with string literals (like `"abc"`)
* Removes explicit class inheritance of `object`, which was only needed to force Python 2 to follow Python 3's new-style class inheritance model
* Removes mentions of Python 2 and Python 3 differences (including enum34, ipaddr, and pip vs pip3)
* Removes `coding: utf-8` source file headers
* Removes now-unnecessary `from __future__ import ...` imports

Closes #605.