### PR TITLE
Introduce sqlalchemy 2.0 compatibility

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Here you can see the full list of changes between each SQLAlchemy-Utils release.
 - Added mixed case support for pg composite (#584, pull request courtesy of bamartin125)
 - Support Python 3.10.
 - Remove the dependency on the six package. (#605)
+- Introduce sqlalchemy 2.0 compatibility. (#513)
 
 
 0.38.2 (2021-12-29)

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ setup(
     platforms='any',
     install_requires=[
         'SQLAlchemy>=1.0',
+        "importlib_metadata ; python_version<'3.8'",
     ],
     extras_require=extras_require,
     python_requires='~=3.6',

--- a/sqlalchemy_utils/aggregates.py
+++ b/sqlalchemy_utils/aggregates.py
@@ -366,10 +366,12 @@ from collections import defaultdict
 from weakref import WeakKeyDictionary
 
 import sqlalchemy as sa
+import sqlalchemy.event
+import sqlalchemy.orm
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.sql.functions import _FunctionGenerator
 
-from .compat import get_scalar_subquery
+from .compat import _select_args, get_scalar_subquery
 from .functions.orm import get_column_key
 from .relationships import (
     chained_join,
@@ -488,10 +490,9 @@ class AggregatedValue:
                 return query.where(
                     local.in_(
                         sa.select(
-                            [remote],
-                            from_obj=[
-                                chained_join(*reversed(self.relationships))
-                            ]
+                            *_select_args(remote)
+                        ).select_from(
+                            chained_join(*reversed(self.relationships))
                         ).where(
                             condition
                         )

--- a/sqlalchemy_utils/compat.py
+++ b/sqlalchemy_utils/compat.py
@@ -27,7 +27,8 @@ if _sqlalchemy_version >= (1, 4):
     from sqlalchemy.orm import declarative_base as _declarative_base
     from sqlalchemy.orm import synonym_for as _synonym_for
 else:
-    from sqlalchemy.ext.declarative import declarative_base as _declarative_base
+    from sqlalchemy.ext.declarative import \
+        declarative_base as _declarative_base
     from sqlalchemy.ext.declarative import synonym_for as _synonym_for
 
 

--- a/sqlalchemy_utils/compat.py
+++ b/sqlalchemy_utils/compat.py
@@ -1,5 +1,75 @@
-def get_scalar_subquery(query):
-    try:
+import sys
+
+if sys.version_info >= (3, 8):
+    from importlib.metadata import metadata
+else:
+    from importlib_metadata import metadata
+
+
+_sqlalchemy_version = tuple(
+    [int(i) for i in metadata("sqlalchemy")["Version"].split(".")[:2]]
+)
+
+
+# In sqlalchemy 2.0, some functions moved to sqlalchemy.orm.
+# In sqlalchemy 1.3, they are only available in .ext.declarative.
+# In sqlalchemy 1.4, they are available in both places.
+#
+# WARNING
+# -------
+#
+# These imports are for internal, private compatibility.
+# They are not supported and may change or move at any time.
+# Do not import these in your own code.
+#
+
+if _sqlalchemy_version >= (1, 4):
+    from sqlalchemy.orm import declarative_base as _declarative_base
+    from sqlalchemy.orm import synonym_for as _synonym_for
+else:
+    from sqlalchemy.ext.declarative import declarative_base as _declarative_base
+    from sqlalchemy.ext.declarative import synonym_for as _synonym_for
+
+
+# scalar subqueries
+if _sqlalchemy_version >= (1, 4):
+    def get_scalar_subquery(query):
         return query.scalar_subquery()
-    except AttributeError:  # SQLAlchemy <1.4
+else:
+    def get_scalar_subquery(query):
         return query.as_scalar()
+
+
+# In sqlalchemy 2.0, select() columns are positional.
+# In sqlalchemy 1.3, select() columns must be wrapped in a list.
+#
+# _select_args() is designed so its return value can be unpacked:
+#
+#     select(*_select_args(1, 2))
+#
+# When sqlalchemy 1.3 support is dropped, remove the call to _select_args()
+# and keep the arguments the same:
+#
+#     select(1, 2)
+#
+# WARNING
+# -------
+#
+# _select_args() is a private, internal function.
+# It is not supported and may change or move at any time.
+# Do not import this in your own code.
+#
+if _sqlalchemy_version >= (1, 4):
+    def _select_args(*args):
+        return args
+else:
+    def _select_args(*args):
+        return [args]
+
+
+__all__ = (
+    "_declarative_base",
+    "get_scalar_subquery",
+    "_select_args",
+    "_synonym_for",
+)

--- a/sqlalchemy_utils/functions/foreign_keys.py
+++ b/sqlalchemy_utils/functions/foreign_keys.py
@@ -336,7 +336,6 @@ def non_indexed_foreign_keys(metadata, engine=None):
         table = Table(
             table_name,
             reflected_metadata,
-            autoload=True,
             autoload_with=metadata.bind or engine
         )
 

--- a/sqlalchemy_utils/generic.py
+++ b/sqlalchemy_utils/generic.py
@@ -35,7 +35,11 @@ class GenericAttributeImpl(attributes.ScalarAttributeImpl):
 
         id = self.get_state_id(state)
 
-        target = session.query(target_class).get(id)
+        try:
+            target = session.get(target_class, id)
+        except AttributeError:
+            # sqlalchemy 1.3
+            target = session.query(target_class).get(id)
 
         # Return found (or not found) target.
         return target

--- a/sqlalchemy_utils/listeners.py
+++ b/sqlalchemy_utils/listeners.py
@@ -143,7 +143,8 @@ def auto_delete_orphans(attr):
         from sqlalchemy.ext.associationproxy import association_proxy
         from sqlalchemy import *
         from sqlalchemy.orm import *
-        from sqlalchemy.ext.declarative import declarative_base
+        # Necessary in sqlalchemy 1.3:
+        # from sqlalchemy.ext.declarative import declarative_base
         from sqlalchemy import event
 
 

--- a/sqlalchemy_utils/relationships/__init__.py
+++ b/sqlalchemy_utils/relationships/__init__.py
@@ -1,6 +1,8 @@
 import sqlalchemy as sa
+import sqlalchemy.orm
 from sqlalchemy.sql.util import ClauseAdapter
 
+from ..compat import _select_args
 from .chained_join import chained_join  # noqa
 
 
@@ -94,7 +96,7 @@ def select_correlated_expression(
 ):
     relationships = list(reversed(path_to_relationships(path, root_model)))
 
-    query = sa.select([expr])
+    query = sa.select(*_select_args(expr))
 
     join_expr, aliases = chained_inverse_join(relationships, leaf_model)
 

--- a/sqlalchemy_utils/types/encrypted/encrypted_type.py
+++ b/sqlalchemy_utils/types/encrypted/encrypted_type.py
@@ -257,7 +257,11 @@ class StringEncryptedType(TypeDecorator, ScalarCoercible):
 
         import sqlalchemy as sa
         from sqlalchemy import create_engine
-        from sqlalchemy.ext.declarative import declarative_base
+        try:
+            from sqlalchemy.orm import declarative_base
+        except ImportError:
+            # sqlalchemy 1.3
+            from sqlalchemy.ext.declarative import declarative_base
         from sqlalchemy.orm import sessionmaker
 
         from sqlalchemy_utils import EncryptedType

--- a/sqlalchemy_utils/view.py
+++ b/sqlalchemy_utils/view.py
@@ -149,7 +149,9 @@ def create_view(
                 Column('premium_user', Boolean, default=False),
             )
 
-        premium_members = select([users]).where(users.c.premium_user == True)
+        premium_members = select(users).where(users.c.premium_user == True)
+        # sqlalchemy 1.3:
+        # premium_members = select([users]).where(users.c.premium_user == True)
         create_view('premium_users', premium_members, metadata)
 
         metadata.create_all(engine) # View is created at this point
@@ -189,8 +191,8 @@ def refresh_materialized_view(session, name, concurrently=False):
     # order to include newly-created/modified objects in the refresh.
     session.flush()
     session.execute(
-        'REFRESH MATERIALIZED VIEW {}{}'.format(
+        sa.text('REFRESH MATERIALIZED VIEW {}{}'.format(
             'CONCURRENTLY ' if concurrently else '',
             session.bind.engine.dialect.identifier_preparer.quote(name)
-        )
+        ))
     )

--- a/tests/aggregate/test_m2m_m2m.py
+++ b/tests/aggregate/test_m2m_m2m.py
@@ -1,5 +1,6 @@
 import pytest
 import sqlalchemy as sa
+import sqlalchemy.orm
 
 from sqlalchemy_utils import aggregated
 
@@ -79,14 +80,16 @@ class TestAggregateManyToManyAndManyToMany:
 
     def test_insert(self, session, Product, Category, Catalog):
         category = Category()
+        session.add(category)
         products = [
             Product(categories=[category]),
             Product(categories=[category])
         ]
+        [session.add(product) for product in products]
         catalog = Catalog(products=products)
         session.add(catalog)
         catalog2 = Catalog(products=products)
-        session.add(catalog)
+        session.add(catalog2)
         session.commit()
         assert catalog.category_count == 1
         assert catalog2.category_count == 1

--- a/tests/aggregate/test_o2m_m2m.py
+++ b/tests/aggregate/test_o2m_m2m.py
@@ -1,5 +1,6 @@
 import pytest
 import sqlalchemy as sa
+import sqlalchemy.orm
 
 from sqlalchemy_utils import aggregated
 
@@ -71,18 +72,21 @@ class TestAggregateOneToManyAndManyToMany:
 
     def test_insert(self, session, Category, Catalog, Product):
         category = Category()
+        session.add(category)
         products = [
             Product(categories=[category]),
             Product(categories=[category])
         ]
+        [session.add(product) for product in products]
         catalog = Catalog(products=products)
         session.add(catalog)
         products2 = [
             Product(categories=[category]),
             Product(categories=[category])
         ]
+        [session.add(product) for product in products2]
         catalog2 = Catalog(products=products2)
-        session.add(catalog)
+        session.add(catalog2)
         session.commit()
         assert catalog.category_count == 1
         assert catalog2.category_count == 1

--- a/tests/functions/test_cast_if.py
+++ b/tests/functions/test_cast_if.py
@@ -1,14 +1,18 @@
 import pytest
 import sqlalchemy as sa
-from sqlalchemy.ext.declarative import declarative_base
+import sqlalchemy.orm
 
 from sqlalchemy_utils import cast_if
-from sqlalchemy_utils.compat import get_scalar_subquery
+from sqlalchemy_utils.compat import (
+    _declarative_base,
+    _select_args,
+    get_scalar_subquery
+)
 
 
 @pytest.fixture(scope='class')
 def base():
-    return declarative_base()
+    return _declarative_base()
 
 
 @pytest.fixture(scope='class')
@@ -40,7 +44,7 @@ class TestCastIf:
         assert cast_if(expr, sa.String) is expr
 
     def test_scalar_selectable(self, article_cls):
-        expr = get_scalar_subquery(sa.select([article_cls.id]))
+        expr = get_scalar_subquery(sa.select(*_select_args(article_cls.id)))
         assert cast_if(expr, sa.Integer) is expr
 
     def test_scalar(self):

--- a/tests/functions/test_get_type.py
+++ b/tests/functions/test_get_type.py
@@ -1,8 +1,9 @@
 import pytest
 import sqlalchemy as sa
+import sqlalchemy.orm
 
 from sqlalchemy_utils import get_type
-from sqlalchemy_utils.compat import get_scalar_subquery
+from sqlalchemy_utils.compat import _select_args, get_scalar_subquery
 
 
 @pytest.fixture
@@ -46,5 +47,5 @@ class TestGetType:
         assert get_type(Article.author) == User
 
     def test_scalar_select(self, Article):
-        query = get_scalar_subquery(sa.select([Article.id]))
+        query = get_scalar_subquery(sa.select(*_select_args(Article.id)))
         assert isinstance(get_type(query), sa.Integer)

--- a/tests/functions/test_json_sql.py
+++ b/tests/functions/test_json_sql.py
@@ -2,6 +2,7 @@ import pytest
 import sqlalchemy as sa
 
 from sqlalchemy_utils import json_sql
+from sqlalchemy_utils.compat import _select_args
 
 
 @pytest.mark.usefixtures('postgresql_dsn')
@@ -21,12 +22,12 @@ class TestJSONSQL:
             ([1, 2], [1, 2]),
             ([], []),
             (
-                [sa.select([sa.text('1')]).label('alias')],
+                [sa.select(*_select_args(sa.text('1'))).label('alias')],
                 [1]
             )
         )
     )
     def test_compiled_scalars(self, connection, value, result):
         assert result == (
-            connection.execute(sa.select([json_sql(value)])).fetchone()[0]
+            connection.execute(sa.select(*_select_args(json_sql(value)))).fetchone()[0]
         )

--- a/tests/functions/test_jsonb_sql.py
+++ b/tests/functions/test_jsonb_sql.py
@@ -2,6 +2,7 @@ import pytest
 import sqlalchemy as sa
 
 from sqlalchemy_utils import jsonb_sql
+from sqlalchemy_utils.compat import _select_args
 
 
 @pytest.mark.usefixtures('postgresql_dsn')
@@ -21,12 +22,12 @@ class TestJSONBSQL:
             ([1, 2], [1, 2]),
             ([], []),
             (
-                [sa.select([sa.text('1')]).label('alias')],
+                [sa.select(*_select_args(sa.text('1'))).label('alias')],
                 [1]
             )
         )
     )
     def test_compiled_scalars(self, connection, value, result):
         assert result == (
-            connection.execute(sa.select([jsonb_sql(value)])).fetchone()[0]
+            connection.execute(sa.select(*_select_args(jsonb_sql(value)))).fetchone()[0]
         )

--- a/tests/functions/test_make_order_by_deterministic.py
+++ b/tests/functions/test_make_order_by_deterministic.py
@@ -1,6 +1,8 @@
 import pytest
 import sqlalchemy as sa
+import sqlalchemy.orm
 
+from sqlalchemy_utils.compat import _select_args
 from sqlalchemy_utils.functions.sort_query import make_order_by_deterministic
 
 from .. import assert_contains
@@ -29,7 +31,8 @@ def User(Base, Article):
         )
 
     User.article_count = sa.orm.column_property(
-        sa.select([sa.func.count()], from_obj=Article)
+        sa.select(*_select_args(sa.func.count()))
+        .select_from(Article)
         .where(Article.author_id == User.id)
         .label('article_count')
     )

--- a/tests/functions/test_render.py
+++ b/tests/functions/test_render.py
@@ -1,6 +1,7 @@
 import pytest
 import sqlalchemy as sa
 
+from sqlalchemy_utils.compat import _select_args
 from sqlalchemy_utils.functions import (
     mock_engine,
     render_expression,
@@ -39,7 +40,7 @@ class TestRender:
         assert 'WHERE user.id = 3' in text
 
     def test_render_statement_without_mapper(self, session):
-        statement = sa.select([sa.text('1')])
+        statement = sa.select(*_select_args(sa.text('1')))
         text = render_statement(statement, bind=session.bind)
 
         assert 'SELECT 1' in text

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -3,6 +3,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 from sqlalchemy_utils import Asterisk, row_to_json
+from sqlalchemy_utils.compat import _declarative_base
 
 
 @pytest.fixture
@@ -28,7 +29,7 @@ def Article(Base):
 
 class TestAsterisk:
     def test_with_table_object(self):
-        Base = sa.ext.declarative.declarative_base()
+        Base = _declarative_base()
 
         class Article(Base):
             __tablename__ = 'article'
@@ -37,7 +38,7 @@ class TestAsterisk:
         assert str(Asterisk(Article.__table__)) == 'article.*'
 
     def test_with_quoted_identifier(self):
-        Base = sa.ext.declarative.declarative_base()
+        Base = _declarative_base()
 
         class User(Base):
             __tablename__ = 'user'

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 import pytest
 import sqlalchemy as sa
+import sqlalchemy.orm
 
 from sqlalchemy_utils import generic_repr, Timestamp
 
@@ -75,7 +76,7 @@ class TestGenericRepr:
         session.add(article)
         session.commit()
 
-        article = session.query(Article).options(sa.orm.defer('name')).one()
+        article = session.query(Article).options(sa.orm.defer(Article.name)).one()
         actual_repr = repr(article)
 
         expected_repr = 'Article(id={}, name=<not loaded>)'.format(article.id)

--- a/tests/types/test_arrow.py
+++ b/tests/types/test_arrow.py
@@ -4,6 +4,7 @@ import pytest
 import sqlalchemy as sa
 from dateutil import tz
 
+from sqlalchemy_utils.compat import _select_args
 from sqlalchemy_utils.types import arrow
 
 
@@ -79,6 +80,6 @@ class TestArrowDateTimeType:
         assert item.published_at.to(timezone) == dt
 
     def test_compilation(self, Article, session):
-        query = sa.select([Article.created_at])
+        query = sa.select(*_select_args(Article.created_at))
         # the type should be cacheable and not throw exception
         session.execute(query)

--- a/tests/types/test_choice.py
+++ b/tests/types/test_choice.py
@@ -3,6 +3,7 @@ import sqlalchemy as sa
 from flexmock import flexmock
 
 from sqlalchemy_utils import Choice, ChoiceType, ImproperlyConfigured
+from sqlalchemy_utils.compat import _select_args
 from sqlalchemy_utils.types.choice import Enum
 
 
@@ -81,7 +82,7 @@ class TestChoiceType:
             ChoiceType([])
 
     def test_compilation(self, User, session):
-        query = sa.select([User.type])
+        query = sa.select(*_select_args(User.type))
         # the type should be cacheable and not throw exception
         session.execute(query)
 

--- a/tests/types/test_color.py
+++ b/tests/types/test_color.py
@@ -3,6 +3,7 @@ import sqlalchemy as sa
 from flexmock import flexmock
 
 from sqlalchemy_utils import ColorType, types  # noqa
+from sqlalchemy_utils.compat import _select_args
 
 
 @pytest.fixture
@@ -62,6 +63,6 @@ class TestColorType:
         assert compiled == "document.bg_color = 'white'"
 
     def test_compilation(self, Document, session):
-        query = sa.select([Document.bg_color])
+        query = sa.select(*_select_args(Document.bg_color))
         # the type should be cacheable and not throw exception
         session.execute(query)

--- a/tests/types/test_composite.py
+++ b/tests/types/test_composite.py
@@ -374,17 +374,17 @@ class TestCompositeTypeWhenTypeAlreadyExistsInDatabase:
         Session = sessionmaker(bind=connection)
         session = Session()
         session.execute(
-            "CREATE TYPE money_type AS (currency VARCHAR, amount INTEGER)"
+            sa.text("CREATE TYPE money_type AS (currency VARCHAR, amount INTEGER)")
         )
         session.execute(
-            """CREATE TABLE account (
+            sa.text("""CREATE TABLE account (
                 id SERIAL, balance MONEY_TYPE, PRIMARY KEY(id)
-            )"""
+            )""")
         )
 
         def teardown():
-            session.execute('DROP TABLE account')
-            session.execute('DROP TYPE money_type')
+            session.execute(sa.text('DROP TABLE account'))
+            session.execute(sa.text('DROP TYPE money_type'))
             session.commit()
             close_all_sessions()
             connection.close()
@@ -436,19 +436,24 @@ class TestCompositeTypeWithMixedCase:
         sa.orm.configure_mappers()
 
         Session = sessionmaker(bind=connection)
-        session = Session()
+        try:
+            # Enable sqlalchemy 2.0 behavior
+            session = Session(future=True)
+        except TypeError:
+            # sqlalchemy 1.3
+            session = Session()
         session.execute(
-            'CREATE TYPE "MoneyType" AS (currency VARCHAR, amount INTEGER)'
+            sa.text('CREATE TYPE "MoneyType" AS (currency VARCHAR, amount INTEGER)')
         )
-        session.execute(
+        session.execute(sa.text(
             """CREATE TABLE account (
                 id SERIAL, balance "MoneyType", PRIMARY KEY(id)
             )"""
-        )
+        ))
 
         def teardown():
-            session.execute('DROP TABLE account')
-            session.execute('DROP TYPE "MoneyType"')
+            session.execute(sa.text('DROP TABLE account'))
+            session.execute(sa.text('DROP TYPE "MoneyType"'))
             session.commit()
             close_all_sessions()
             connection.close()

--- a/tests/types/test_country.py
+++ b/tests/types/test_country.py
@@ -2,6 +2,7 @@ import pytest
 import sqlalchemy as sa
 
 from sqlalchemy_utils import Country, CountryType, i18n  # noqa
+from sqlalchemy_utils.compat import _select_args
 
 
 @pytest.fixture
@@ -45,6 +46,6 @@ class TestCountryType:
         assert compiled == '"user".country = \'FI\''
 
     def test_compilation(self, User, session):
-        query = sa.select([User.country])
+        query = sa.select(*_select_args(User.country))
         # the type should be cacheable and not throw exception
         session.execute(query)

--- a/tests/types/test_currency.py
+++ b/tests/types/test_currency.py
@@ -2,6 +2,7 @@ import pytest
 import sqlalchemy as sa
 
 from sqlalchemy_utils import Currency, CurrencyType, i18n
+from sqlalchemy_utils.compat import _select_args
 
 
 @pytest.fixture
@@ -54,6 +55,6 @@ class TestCurrencyType:
         assert compiled == '"user".currency = \'USD\''
 
     def test_compilation(self, User, session):
-        query = sa.select([User.currency])
+        query = sa.select(*_select_args(User.currency))
         # the type should be cacheable and not throw exception
         session.execute(query)

--- a/tests/types/test_date_range.py
+++ b/tests/types/test_date_range.py
@@ -4,6 +4,7 @@ import pytest
 import sqlalchemy as sa
 
 from sqlalchemy_utils import DateRangeType
+from sqlalchemy_utils.compat import _select_args
 
 intervals = None
 inf = 0
@@ -83,7 +84,7 @@ class DateRangeTestCase:
         assert booking.during.upper == datetime(2015, 1, 1).date()
 
     def test_compilation(self, session, Booking):
-        query = sa.select([Booking.during])
+        query = sa.select(*_select_args(Booking.during))
 
         # the type should be cacheable and not throw exception
         session.execute(query)

--- a/tests/types/test_datetime_range.py
+++ b/tests/types/test_datetime_range.py
@@ -4,6 +4,7 @@ import pytest
 import sqlalchemy as sa
 
 from sqlalchemy_utils import DateTimeRangeType
+from sqlalchemy_utils.compat import _select_args
 
 intervals = None
 inf = 0
@@ -83,7 +84,7 @@ class DateTimeRangeTestCase:
         assert booking.during.upper == datetime(2015, 1, 1)
 
     def test_compilation(self, session, Booking):
-        query = sa.select([Booking.during])
+        query = sa.select(*_select_args(Booking.during))
 
         # the type should be cacheable and not throw exception
         session.execute(query)

--- a/tests/types/test_email.py
+++ b/tests/types/test_email.py
@@ -2,6 +2,7 @@ import pytest
 import sqlalchemy as sa
 
 from sqlalchemy_utils import EmailType
+from sqlalchemy_utils.compat import _select_args
 
 
 @pytest.fixture
@@ -36,6 +37,6 @@ class TestEmailType:
         assert User.short_email.type.impl.length == 70
 
     def test_compilation(self, User, session):
-        query = sa.select([User.email])
+        query = sa.select(*_select_args(User.email))
         # the type should be cacheable and not throw exception
         session.execute(query)

--- a/tests/types/test_encrypted.py
+++ b/tests/types/test_encrypted.py
@@ -205,7 +205,11 @@ def user(
     session.add(user)
     session.commit()
 
-    return session.query(User).get(user.id)
+    try:
+        return session.get(User, user.id)
+    except AttributeError:
+        # sqlalchemy 1.3
+        return session.query(User).get(user.id)
 
 
 @pytest.fixture
@@ -316,7 +320,11 @@ class EncryptedTypeTestCase:
             id=team_1_id
         ).one()[0]
 
-        team = session.query(Team).get(team_1_id)
+        try:
+            team = session.get(Team, team_1_id)
+        except AttributeError:
+            # sqlalchemy 1.3
+            team = session.query(Team).get(team_1_id)
 
         assert team.name == 'One'
 
@@ -326,7 +334,11 @@ class EncryptedTypeTestCase:
             id=team_2_id
         ).one()[0]
 
-        team = session.query(Team).get(team_2_id)
+        try:
+            team = session.get(Team, team_2_id)
+        except AttributeError:
+            # sqlalchemy 1.3
+            team = session.query(Team).get(team_2_id)
 
         assert team.name == 'Two'
 

--- a/tests/types/test_enriched_date_pendulum.py
+++ b/tests/types/test_enriched_date_pendulum.py
@@ -3,6 +3,7 @@ from datetime import date
 import pytest
 import sqlalchemy as sa
 
+from sqlalchemy_utils.compat import _select_args
 from sqlalchemy_utils.types.enriched_datetime import (
     enriched_date_type,
     pendulum_date
@@ -66,6 +67,6 @@ class TestPendulumDateType:
         assert compiled == "users.birthday > '2015-01-01'"
 
     def test_compilation(self, User, session):
-        query = sa.select([User.birthday])
+        query = sa.select(*_select_args(User.birthday))
         # the type should be cacheable and not throw exception
         session.execute(query)

--- a/tests/types/test_enriched_datetime_arrow.py
+++ b/tests/types/test_enriched_datetime_arrow.py
@@ -4,6 +4,7 @@ import pytest
 import sqlalchemy as sa
 from dateutil import tz
 
+from sqlalchemy_utils.compat import _select_args
 from sqlalchemy_utils.types.enriched_datetime import (
     arrow_datetime,
     enriched_datetime_type
@@ -90,6 +91,6 @@ class TestArrowDateTimeType:
         assert item.published_at.to(timezone) == dt
 
     def test_compilation(self, Article, session):
-        query = sa.select([Article.published_at])
+        query = sa.select(*_select_args(Article.published_at))
         # the type should be cacheable and not throw exception
         session.execute(query)

--- a/tests/types/test_int_range.py
+++ b/tests/types/test_int_range.py
@@ -2,7 +2,7 @@ import pytest
 import sqlalchemy as sa
 
 from sqlalchemy_utils import IntRangeType
-from sqlalchemy_utils.compat import get_scalar_subquery
+from sqlalchemy_utils.compat import _select_args, get_scalar_subquery
 
 intervals = None
 inf = -1
@@ -101,7 +101,7 @@ class NumberRangeTestCase:
         assert building.persons_at_night.upper == 15
 
     def test_compilation(self, session, Building):
-        query = sa.select([Building.persons_at_night])
+        query = sa.select(*_select_args(Building.persons_at_night))
 
         # the type should be cacheable and not throw exception
         session.execute(query)

--- a/tests/types/test_ip_address.py
+++ b/tests/types/test_ip_address.py
@@ -1,6 +1,7 @@
 import pytest
 import sqlalchemy as sa
 
+from sqlalchemy_utils.compat import _select_args
 from sqlalchemy_utils.types import ip_address
 
 
@@ -35,6 +36,6 @@ class TestIPAddressType:
         assert str(visitor.ip_address) == '111.111.111.111'
 
     def test_compilation(self, Visitor, session):
-        query = sa.select([Visitor.ip_address])
+        query = sa.select(*_select_args(Visitor.ip_address))
         # the type should be cacheable and not throw exception
         session.execute(query)

--- a/tests/types/test_json.py
+++ b/tests/types/test_json.py
@@ -2,6 +2,7 @@ import pytest
 import sqlalchemy as sa
 import sqlalchemy.orm as sa_orm
 
+from sqlalchemy_utils.compat import _select_args
 from sqlalchemy_utils.types import json
 
 
@@ -75,7 +76,7 @@ class JSONTestCase:
         assert document.json == {'something': 'äääööö'}
 
     def test_compilation(self, Document, session):
-        query = sa.select([Document.json])
+        query = sa.select(*_select_args(Document.json))
         # the type should be cacheable and not throw exception
         session.execute(query)
 

--- a/tests/types/test_locale.py
+++ b/tests/types/test_locale.py
@@ -1,6 +1,7 @@
 import pytest
 import sqlalchemy as sa
 
+from sqlalchemy_utils.compat import _select_args
 from sqlalchemy_utils.types import locale
 
 
@@ -61,7 +62,7 @@ class TestLocaleType:
         assert compiled == '"user".locale = \'en_US\''
 
     def test_compilation(self, User, session):
-        query = sa.select([User.locale])
+        query = sa.select(*_select_args(User.locale))
 
         # the type should be cacheable and not throw exception
         session.execute(query)

--- a/tests/types/test_ltree.py
+++ b/tests/types/test_ltree.py
@@ -2,6 +2,7 @@ import pytest
 import sqlalchemy as sa
 
 from sqlalchemy_utils import Ltree, LtreeType
+from sqlalchemy_utils.compat import _select_args
 
 
 @pytest.fixture
@@ -16,7 +17,8 @@ def Section(Base):
 
 @pytest.fixture
 def init_models(Section, connection):
-    connection.execute('CREATE EXTENSION IF NOT EXISTS ltree')
+    with connection.begin():
+        connection.execute(sa.text('CREATE EXTENSION IF NOT EXISTS ltree'))
     pass
 
 
@@ -41,6 +43,6 @@ class TestLTREE:
         assert compiled == 'section.path = \'path\''
 
     def test_compilation(self, Section, session):
-        query = sa.select([Section.path])
+        query = sa.select(*_select_args(Section.path))
         # the type should be cacheable and not throw exception
         session.execute(query)

--- a/tests/types/test_numeric_range.py
+++ b/tests/types/test_numeric_range.py
@@ -4,6 +4,7 @@ import pytest
 import sqlalchemy as sa
 
 from sqlalchemy_utils import NumericRangeType
+from sqlalchemy_utils.compat import _select_args
 
 intervals = None
 inf = 0
@@ -90,7 +91,7 @@ class NumericRangeTestCase:
         assert car.price_range.upper == 15
 
     def test_compilation(self, session, Car):
-        query = sa.select([Car.price_range])
+        query = sa.select(*_select_args(Car.price_range))
 
         # the type should be cacheable and not throw exception
         session.execute(query)

--- a/tests/types/test_password.py
+++ b/tests/types/test_password.py
@@ -9,6 +9,7 @@ import sqlalchemy.dialects.sqlite
 from sqlalchemy import inspect
 
 from sqlalchemy_utils import Password, PasswordType, types  # noqa
+from sqlalchemy_utils.compat import _select_args
 
 
 @pytest.fixture
@@ -95,7 +96,11 @@ class TestPasswordType:
         session.add(obj)
         session.commit()
 
-        obj = session.query(User).get(obj.id)
+        try:
+            obj = session.get(User, obj.id)
+        except AttributeError:
+            # sqlalchemy 1.3
+            obj = session.query(User).get(obj.id)
 
         assert obj.password == b'b'
         assert obj.password != 'a'
@@ -157,7 +162,11 @@ class TestPasswordType:
         session.add(obj)
         session.commit()
 
-        obj = session.query(User).get(obj.id)
+        try:
+            obj = session.get(User, obj.id)
+        except AttributeError:
+            # sqlalchemy 1.3
+            obj = session.query(User).get(obj.id)
 
         assert obj.password is None
 
@@ -173,7 +182,11 @@ class TestPasswordType:
         session.add(obj)
         session.commit()
 
-        obj = session.query(User).get(obj.id)
+        try:
+            obj = session.get(User, obj.id)
+        except AttributeError:
+            # sqlalchemy 1.3
+            obj = session.query(User).get(obj.id)
         obj.password = 'b'
 
         session.commit()
@@ -213,7 +226,11 @@ class TestPasswordType:
 
         session.commit()
 
-        obj = session.query(User).get(obj.id)
+        try:
+            obj = session.get(User, obj.id)
+        except AttributeError:
+            # sqlalchemy 1.3
+            obj = session.query(User).get(obj.id)
 
         assert obj.password.hash.decode('utf8').startswith('$pbkdf2-sha512$')
         assert obj.password == 'b'
@@ -257,6 +274,6 @@ class TestPasswordType:
         assert not onload.called
 
     def test_compilation(self, User, session):
-        query = sa.select([User.password])
+        query = sa.select(*_select_args(User.password))
         # the type should be cacheable and not throw exception
         session.execute(query)

--- a/tests/types/test_phonenumber.py
+++ b/tests/types/test_phonenumber.py
@@ -1,5 +1,6 @@
 import pytest
 import sqlalchemy as sa
+import sqlalchemy.orm
 
 from sqlalchemy_utils import (  # noqa
     PhoneNumber,
@@ -7,6 +8,7 @@ from sqlalchemy_utils import (  # noqa
     PhoneNumberType,
     types
 )
+from sqlalchemy_utils.compat import _select_args
 
 VALID_PHONE_NUMBERS = (
     "040 1234567",
@@ -111,7 +113,8 @@ class TestPhoneNumberType:
 
     def test_phone_number_is_stored_as_string(self, session, user):
         result = session.execute(
-            'SELECT phone_number FROM "user" WHERE id=:param', {"param": user.id}
+            sa.text('SELECT phone_number FROM "user" WHERE id=:param'),
+            {"param": user.id},
         )
         assert result.first()[0] == "+358401234567"
 
@@ -145,7 +148,8 @@ class TestPhoneNumberType:
         queried_user = session.query(User)[1]
         assert queried_user.phone_number is None
         result = session.execute(
-            'SELECT phone_number FROM "user" WHERE id=:param', {"param": user.id}
+            sa.text('SELECT phone_number FROM "user" WHERE id=:param'),
+            {"param": user.id},
         )
         assert result.first()[0] is None
 
@@ -155,7 +159,7 @@ class TestPhoneNumberType:
         assert isinstance(user.phone_number, PhoneNumber)
 
     def test_compilation(self, User, session):
-        query = sa.select([User.phone_number])
+        query = sa.select(*_select_args(User.phone_number))
         # the type should be cacheable and not throw exception
         session.execute(query)
 

--- a/tests/types/test_scalar_list.py
+++ b/tests/types/test_scalar_list.py
@@ -1,7 +1,9 @@
 import pytest
 import sqlalchemy as sa
+import sqlalchemy.exc
 
 from sqlalchemy_utils import ScalarListType
+from sqlalchemy_utils.compat import _select_args
 
 
 class TestScalarIntegerList:
@@ -93,6 +95,6 @@ class TestScalarUnicodeList:
         assert user.some_list == []
 
     def test_compilation(self, User, session):
-        query = sa.select([User.some_list])
+        query = sa.select(*_select_args(User.some_list))
         # the type should be cacheable and not throw exception
         session.execute(query)

--- a/tests/types/test_timezone.py
+++ b/tests/types/test_timezone.py
@@ -8,6 +8,7 @@ try:
 except ImportError:
     from backports import zoneinfo
 
+from sqlalchemy_utils.compat import _select_args
 from sqlalchemy_utils.types import timezone, TimezoneType
 
 
@@ -62,7 +63,7 @@ class TestTimezoneType:
         assert visitor_zoneinfo is not None
 
     def test_compilation(self, Visitor, session):
-        query = sa.select([Visitor.timezone_pytz])
+        query = sa.select(*_select_args(Visitor.timezone_pytz))
         # the type should be cacheable and not throw exception
         session.execute(query)
 

--- a/tests/types/test_tsvector.py
+++ b/tests/types/test_tsvector.py
@@ -36,8 +36,7 @@ class TestTSVector:
         table = sa.schema.Table(
             'user',
             reflected_metadata,
-            autoload=True,
-            autoload_with=engine
+            autoload_with=engine,
         )
         assert isinstance(table.c['search_index'].type, TSVECTOR)
 

--- a/tests/types/test_url.py
+++ b/tests/types/test_url.py
@@ -1,6 +1,7 @@
 import pytest
 import sqlalchemy as sa
 
+from sqlalchemy_utils.compat import _select_args
 from sqlalchemy_utils.types import url
 
 
@@ -40,6 +41,6 @@ class TestURLType:
         assert isinstance(user.website, url.furl)
 
     def test_compilation(self, User, session):
-        query = sa.select([User.website])
+        query = sa.select(*_select_args(User.website))
         # the type should be cacheable and not throw exception
         session.execute(query)

--- a/tests/types/test_uuid.py
+++ b/tests/types/test_uuid.py
@@ -5,6 +5,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 from sqlalchemy_utils import UUIDType
+from sqlalchemy_utils.compat import _select_args
 
 
 @pytest.fixture
@@ -58,7 +59,7 @@ class TestUUIDType:
         assert obj.id.bytes == identifier
 
     def test_compilation(self, User, session):
-        query = sa.select([User.id])
+        query = sa.select(*_select_args(User.id))
 
         # the type should be cacheable and not throw exception
         session.execute(query)

--- a/tests/types/test_weekdays.py
+++ b/tests/types/test_weekdays.py
@@ -2,6 +2,7 @@ import pytest
 import sqlalchemy as sa
 
 from sqlalchemy_utils import i18n
+from sqlalchemy_utils.compat import _select_args
 from sqlalchemy_utils.primitives import WeekDays
 from sqlalchemy_utils.types import WeekDaysType
 
@@ -47,7 +48,7 @@ class WeekDaysTypeTestCase:
         assert isinstance(schedule.working_days, WeekDays)
 
     def test_compilation(self, Schedule, session):
-        query = sa.select([Schedule.working_days])
+        query = sa.select(*_select_args(Schedule.working_days))
         # the type should be cacheable and not throw exception
         session.execute(query)
 

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,8 @@ deps =
     sqlalchemy1_4_27: SQLAlchemy==1.4.27
     ; sqlalchemy 1.4.30 introduced UUID literal quoting. See #580.
     sqlalchemy1_4_29: SQLAlchemy==1.4.29
+setenv =
+    SQLALCHEMY_WARN_20 = true
 passenv =
     SQLALCHEMY_UTILS_TEST_*
 recreate = True


### PR DESCRIPTION
This patch introduces the following changes:

* Enable sqlalchemy 2.0 compatibility warnings during unit testing.
* Update the code, docstrings, and unit tests to support sqlalchemy 2.0 behavior and syntax.

Most of the warnings revolved around the following incompatibilities:

* sqlalchemy 2.0 no longer auto-adds objects across backref relationships.
* sqlalchemy 2.0 no longer auto-commits objects.
* Raw SQL strings must always be wrapped in calls to `sqlalchemy.text()`.
* `Query.get()` calls must migrate to `Session.get()`.
* `select()` calls must use positional parameters and must use generative method calls instead of keyword arguments (e.g. `select(..., fromobj=...)` must become `select(...).select_from(...)`).

Closes #513.
