### PR TITLE
Fix `database_exists()` for Oracle

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Changelog
 Here you can see the full list of changes between each SQLAlchemy-Utils release.
 
 
+Unreleased
+^^^^^^^^^^
+
+- Fixed ``database_exists()`` for Oracle. (#627)
+
+
 0.38.3 (2022-07-11)
 ^^^^^^^^^^^^^^^^^^^
 

--- a/sqlalchemy_utils/functions/database.py
+++ b/sqlalchemy_utils/functions/database.py
@@ -506,6 +506,15 @@ def database_exists(url):
                 # The default SQLAlchemy database is in memory, and :memory: is
                 # not required, thus we should support that use case.
                 return True
+
+        elif dialect_name == 'oracle':
+            url = _set_url_database(url, database=None)
+            engine = sa.create_engine(url)
+            text = (
+                "SELECT name FROM master.dbo.sysdatabases WHERE name = '%s'" % database
+            )
+            return bool(_get_scalar_result(engine, sa.text(text)))
+
         else:
             text = 'SELECT 1'
             try:

--- a/sqlalchemy_utils/functions/database.py
+++ b/sqlalchemy_utils/functions/database.py
@@ -439,8 +439,8 @@ def _set_url_database(url: sa.engine.url.URL, database):
 
 
 def _get_scalar_result(engine, sql):
-    with engine.begin() as conn:
-        return conn.scalar(sql)
+    connection = engine.connect()
+    return connection.scalar(sql)
 
 
 def _sqlite_file_exists(database):


### PR DESCRIPTION
There was no Oracle-specific branch in the `database_exists()` code, but the fall-through `SELECT 1` query was not compatible with Oracle.

@visuman, please let me know if this branch fixes the crash that you're seeing. Please test against the following scenarios:

- [ ] Test for a database that is known to exist.
- [ ] Test for a database that is known to NOT exist.
- [ ] Verify the behavior of other scenarios involving permissions. For example:
  - [ ] Test for databases you know you don't have permission to access.
  - [ ] Test behavior when you don't have permission to query `master.dbo.sysdatabases` (if this is even possible...I don't know!).

I'll update as needed based on your feedback, and merge once you're no longer seeing crashes. Thanks!

Fixes #627