### PR TITLE
Update color.py for colour-science compatibility

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,14 @@ Changelog
 Here you can see the full list of changes between each SQLAlchemy-Utils release.
 
 
+Unreleased
+^^^^^^^^^^
+
+- Fix a crash that occurs if the ``colour-science`` package is installed,
+  which shares the same import name as the ``colour`` package that sqlalchemy-utils supports.
+  (`#637 <https://github.com/kvesteri/sqlalchemy-utils/pull/637>`_, courtesy of JayPalm)
+
+
 0.38.3 (2022-07-11)
 ^^^^^^^^^^^^^^^^^^^
 

--- a/sqlalchemy_utils/types/color.py
+++ b/sqlalchemy_utils/types/color.py
@@ -7,7 +7,7 @@ colour = None
 try:
     import colour
     python_colour_type = colour.Color
-except ImportError:
+except (ImportError, AttributeError):
     python_colour_type = None
 
 


### PR DESCRIPTION
This will allow SQLAlchemy-Utils to be compatible with `colour-science` Currently, this import makes this package incompatible with `colour-science` due to conflicting `colour` namespace. Since the `colour` package is already optional, this will allow `sqlalchemy-utils` to be used with `colour-science` without conflict. See [#636](https://github.com/kvesteri/sqlalchemy-utils/issues/636) for the associated issue/discussion.

Closes #636