### PR TITLE
Update view.py with changes proposed by @claudiopastorini

### DIFF
--- a/sqlalchemy_utils/view.py
+++ b/sqlalchemy_utils/view.py
@@ -14,7 +14,7 @@ class CreateView(DDLElement):
 
 @compiler.compiles(CreateView)
 def compile_create_materialized_view(element, compiler, **kw):
-    return 'CREATE {}VIEW {} AS {}'.format(
+    return 'CREATE {}VIEW IF NOT EXISTS {} AS {}'.format(
         'MATERIALIZED ' if element.materialized else '',
         compiler.dialect.identifier_preparer.quote(element.name),
         compiler.sql_compiler.process(element.selectable, literal_binds=True),


### PR DESCRIPTION
This will prevent the 'already_exists' error for views. https://github.com/dybricks/sqlalchemy-utils/pull/1