### PR TITLE
fix database_exists() for Oracle

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Unreleased
 - Fix a crash that occurs if the ``colour-science`` package is installed,
   which shares the same import name as the ``colour`` package that sqlalchemy-utils supports.
   (`#637 <https://github.com/kvesteri/sqlalchemy-utils/pull/637>`_, courtesy of JayPalm)
+- Fixed ``database_exists()`` for Oracle. (#627)
 
 
 0.38.3 (2022-07-11)

--- a/sqlalchemy_utils/functions/database.py
+++ b/sqlalchemy_utils/functions/database.py
@@ -506,6 +506,16 @@ def database_exists(url):
                 # The default SQLAlchemy database is in memory, and :memory: is
                 # not required, thus we should support that use case.
                 return True
+
+        elif dialect_name == 'oracle':
+            engine = sa.create_engine(url)
+            # Oracle makes use of schemas which is same as user
+            user_name = engine.url.username
+            text = (
+                "SELECT username FROM ALL_USERS WHERE lower(username) = lower('%s')" % user_name
+            )
+            return bool(_get_scalar_result(engine, sa.text(text)))
+
         else:
             text = 'SELECT 1'
             try:


### PR DESCRIPTION
database_exists for oracle was failing
as 'SELECT 1' in oracle is not a vaild syntax.
Fixing the issue by handling the oracle case seperately. Fixes #627