### PR TITLE
Fix version comparison in UUID type

### DIFF
--- a/sqlalchemy_utils/types/uuid.py
+++ b/sqlalchemy_utils/types/uuid.py
@@ -1,11 +1,12 @@
 import uuid
 
+from packaging.version import Version
 from sqlalchemy import __version__, types, util
 from sqlalchemy.dialects import mssql, postgresql
 
 from .scalar_coercible import ScalarCoercible
 
-sqlalchemy_version = tuple([int(v) for v in __version__.split(".")])
+sqlalchemy_version = Version(__version__)
 
 
 class UUIDType(ScalarCoercible, types.TypeDecorator):
@@ -71,7 +72,7 @@ class UUIDType(ScalarCoercible, types.TypeDecorator):
 
     # sqlalchemy >= 1.4.30 quotes UUID's automatically.
     # It is only necessary to quote UUID's in sqlalchemy < 1.4.30.
-    if sqlalchemy_version < (1, 4, 30):
+    if sqlalchemy_version < Version("1.4.30"):
         def process_literal_param(self, value, dialect):
             return "'{}'".format(value) if value else value
     else:


### PR DESCRIPTION
Recent versions of sqlalchemy have non-digit characters (for example, [here](https://github.com/sqlalchemy/sqlalchemy/blob/8e3ec05b2e4b3f22089b531b737c12c249fd2d8e/lib/sqlalchemy/__init__.py#L260)), which is why this line sometimes breaks.

It is a better practice to use Version class from packaging.version standard library to compare versions.