### PR TITLE
Fix a version-parsing crash when a sqlalchemy beta is installed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.py[cod]
+__pycache__
 
 # C extensions
 *.so

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ Unreleased
 - Fix a crash that occurs if the ``colour-science`` package is installed,
   which shares the same import name as the ``colour`` package that sqlalchemy-utils supports.
   (`#637 <https://github.com/kvesteri/sqlalchemy-utils/pull/637>`_, courtesy of JayPalm)
+- Fix a crash that occurs if the installed sqlalchemy version is a beta (like ``"2.0.0b3"``).
+  (Reported in `#643 <https://github.com/kvesteri/sqlalchemy-utils/pull/643>`_, thanks Dinmukhamet!)
 
 
 0.38.3 (2022-07-11)

--- a/sqlalchemy_utils/compat.py
+++ b/sqlalchemy_utils/compat.py
@@ -1,3 +1,4 @@
+import re
 import sys
 
 if sys.version_info >= (3, 8):
@@ -6,9 +7,17 @@ else:
     from importlib_metadata import metadata
 
 
-_sqlalchemy_version = tuple(
-    [int(i) for i in metadata("sqlalchemy")["Version"].split(".")[:2]]
-)
+def get_sqlalchemy_version(version=metadata("sqlalchemy")["Version"]):
+    """Extract the sqlalchemy version as a tuple of integers."""
+
+    match = re.search(r"^(\d+)(?:\.(\d+)(?:\.(\d+))?)?", version)
+    try:
+        return tuple(int(v) for v in match.groups() if v is not None)
+    except AttributeError:
+        return ()
+
+
+_sqlalchemy_version = get_sqlalchemy_version()
 
 
 # In sqlalchemy 2.0, some functions moved to sqlalchemy.orm.
@@ -71,6 +80,7 @@ else:
 __all__ = (
     "_declarative_base",
     "get_scalar_subquery",
+    "get_sqlalchemy_version",
     "_select_args",
     "_synonym_for",
 )

--- a/sqlalchemy_utils/types/uuid.py
+++ b/sqlalchemy_utils/types/uuid.py
@@ -1,11 +1,12 @@
 import uuid
 
-from sqlalchemy import __version__, types, util
+from sqlalchemy import types, util
 from sqlalchemy.dialects import mssql, postgresql
 
+from ..compat import get_sqlalchemy_version
 from .scalar_coercible import ScalarCoercible
 
-sqlalchemy_version = tuple([int(v) for v in __version__.split(".")])
+sqlalchemy_version = get_sqlalchemy_version()
 
 
 class UUIDType(ScalarCoercible, types.TypeDecorator):

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,0 +1,20 @@
+import pytest
+
+import sqlalchemy_utils.compat
+
+
+@pytest.mark.parametrize(
+    "version, expected",
+    (
+        ("2.0.0b3", (2, 0, 0)),
+        ("2.0.0b", (2, 0, 0)),
+        ("2.0.0", (2, 0, 0)),
+        ("2.0.", (2, 0)),
+        ("2.0", (2, 0)),
+        ("2.", (2,)),
+        ("2", (2,)),
+        ("", ()),
+    ),
+)
+def test_get_sqlalchemy_version(version, expected):
+    assert sqlalchemy_utils.compat.get_sqlalchemy_version(version) == expected


### PR DESCRIPTION
This addresses a bug reported in PR #643.