### PR TITLE
Use pre-commit

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,3 +12,6 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 indent_size = 4
+
+[*.yaml]
+indent_size = 2

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,13 +6,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.10']
+        python-version: ['3.11']
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install tox
         run: pip install tox
       - name: Run linting
-        run: tox -e lint
+        run: tox -e flake8,isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,31 @@
+# Run `pre-commit autoupdate` to update the hook versions.
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+
+  - repo: https://github.com/PyCQA/flake8
+    rev: 5.0.4
+    hooks:
+      - id: flake8
+
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+
+      # Allow tox to run isort as a linter.
+      - id: isort
+        alias: isort-check
+        args: [--check]
+        stages: [manual]
+
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.1.0
+    hooks:
+      - id: pyupgrade
+        args: [--py36-plus]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Unreleased
 ^^^^^^^^^^
 
 - Support Python 3.11.
+- Add pre-commit hooks for uniform text checks, isort, flake8, and pyupgrade.
 - Fix a crash that occurs if the ``colour-science`` package is installed,
   which shares the same import name as the ``colour`` package that sqlalchemy-utils supports.
   (`#637 <https://github.com/kvesteri/sqlalchemy-utils/pull/637>`_, courtesy of JayPalm)

--- a/conftest.py
+++ b/conftest.py
@@ -73,7 +73,7 @@ def mysql_db_user():
 @pytest.fixture
 def postgresql_dsn(postgresql_db_user, postgresql_db_password, postgresql_db_host,
                    db_name):
-    return 'postgresql://{0}:{1}@{2}/{3}'.format(
+    return 'postgresql://{}:{}@{}/{}'.format(
         postgresql_db_user,
         postgresql_db_password,
         postgresql_db_host,
@@ -83,7 +83,7 @@ def postgresql_dsn(postgresql_db_user, postgresql_db_password, postgresql_db_hos
 
 @pytest.fixture
 def mysql_dsn(mysql_db_user, db_name):
-    return 'mysql+pymysql://{0}@localhost/{1}'.format(mysql_db_user, db_name)
+    return f'mysql+pymysql://{mysql_db_user}@localhost/{db_name}'
 
 
 @pytest.fixture
@@ -98,7 +98,7 @@ def sqlite_none_database_dsn():
 
 @pytest.fixture
 def sqlite_file_dsn(db_name):
-    return 'sqlite:///{0}.db'.format(db_name)
+    return f'sqlite:///{db_name}.db'
 
 
 @pytest.fixture
@@ -121,7 +121,7 @@ def mssql_db_driver():
 
 @pytest.fixture
 def mssql_dsn(mssql_db_user, mssql_db_password, mssql_db_driver, db_name):
-    return 'mssql+pyodbc://{0}:{1}@localhost/{2}?driver={3}'\
+    return 'mssql+pyodbc://{}:{}@localhost/{}?driver={}'\
         .format(mssql_db_user, mssql_db_password, db_name, mssql_db_driver)
 
 
@@ -177,7 +177,7 @@ def Category(Base):
 
         @hybrid_property
         def full_name(self):
-            return '%s %s' % (self.title, self.name)
+            return f'{self.title} {self.name}'
 
         @full_name.expression
         def full_name(self):

--- a/sqlalchemy_utils/aggregates.py
+++ b/sqlalchemy_utils/aggregates.py
@@ -391,7 +391,7 @@ class AggregatedAttribute(declared_attr):
         *args,
         **kwargs
     ):
-        super(AggregatedAttribute, self).__init__(fget, *args, **kwargs)
+        super().__init__(fget, *args, **kwargs)
         self.__doc__ = fget.__doc__
         self.column = column
         self.relationship = relationship

--- a/sqlalchemy_utils/expressions.py
+++ b/sqlalchemy_utils/expressions.py
@@ -24,7 +24,7 @@ def compile_array_get(element, compiler, **kw):
         raise Exception(
             "Second argument should be an integer."
         )
-    return '(%s)[%s]' % (
+    return '({})[{}]'.format(
         compiler.process(args[0]),
         sa.text(str(args[1].value + 1))
     )
@@ -37,7 +37,7 @@ class row_to_json(GenericFunction):
 
 @compiles(row_to_json, 'postgresql')
 def compile_row_to_json(element, compiler, **kw):
-    return "%s(%s)" % (element.name, compiler.process(element.clauses))
+    return f"{element.name}({compiler.process(element.clauses)})"
 
 
 class json_array_length(GenericFunction):
@@ -47,7 +47,7 @@ class json_array_length(GenericFunction):
 
 @compiles(json_array_length, 'postgresql')
 def compile_json_array_length(element, compiler, **kw):
-    return "%s(%s)" % (element.name, compiler.process(element.clauses))
+    return f"{element.name}({compiler.process(element.clauses)})"
 
 
 class Asterisk(ColumnElement):

--- a/sqlalchemy_utils/functions/database.py
+++ b/sqlalchemy_utils/functions/database.py
@@ -93,7 +93,7 @@ def json_sql(value, scalars_to_json=True):
             )
         )
     elif isinstance(value, str):
-        return scalar_convert("'{0}'".format(value))
+        return scalar_convert(f"'{value}'")
     elif isinstance(value, Sequence):
         return sa.func.json_build_array(
             *(
@@ -165,7 +165,7 @@ def jsonb_sql(value, scalars_to_jsonb=True):
             )
         )
     elif isinstance(value, str):
-        return scalar_convert("'{0}'".format(value))
+        return scalar_convert(f"'{value}'")
     elif isinstance(value, Sequence):
         return sa.func.jsonb_build_array(
             *(
@@ -565,7 +565,7 @@ def create_database(url, encoding='utf8', template=None):
         if not template:
             template = 'template1'
 
-        text = "CREATE DATABASE {0} ENCODING '{1}' TEMPLATE {2}".format(
+        text = "CREATE DATABASE {} ENCODING '{}' TEMPLATE {}".format(
             quote(engine, database),
             encoding,
             quote(engine, template)
@@ -575,7 +575,7 @@ def create_database(url, encoding='utf8', template=None):
             connection.execute(sa.text(text))
 
     elif dialect_name == 'mysql':
-        text = "CREATE DATABASE {0} CHARACTER SET = '{1}'".format(
+        text = "CREATE DATABASE {} CHARACTER SET = '{}'".format(
             quote(engine, database),
             encoding
         )
@@ -589,7 +589,7 @@ def create_database(url, encoding='utf8', template=None):
                 connection.execute(sa.text("DROP TABLE DB;"))
 
     else:
-        text = 'CREATE DATABASE {0}'.format(quote(engine, database))
+        text = f'CREATE DATABASE {quote(engine, database)}'
         with engine.begin() as connection:
             connection.execute(sa.text(text))
 
@@ -642,18 +642,18 @@ def drop_database(url):
                 'pid' if (version >= (9, 2)) else 'procpid'
             )
             text = '''
-            SELECT pg_terminate_backend(pg_stat_activity.%(pid_column)s)
+            SELECT pg_terminate_backend(pg_stat_activity.{pid_column})
             FROM pg_stat_activity
-            WHERE pg_stat_activity.datname = '%(database)s'
-            AND %(pid_column)s <> pg_backend_pid();
-            ''' % {'pid_column': pid_column, 'database': database}
+            WHERE pg_stat_activity.datname = '{database}'
+            AND {pid_column} <> pg_backend_pid();
+            '''.format(pid_column=pid_column, database=database)
             connection.execute(sa.text(text))
 
             # Drop the database.
-            text = 'DROP DATABASE {0}'.format(quote(connection, database))
+            text = f'DROP DATABASE {quote(connection, database)}'
             connection.execute(sa.text(text))
     else:
-        text = 'DROP DATABASE {0}'.format(quote(engine, database))
+        text = f'DROP DATABASE {quote(engine, database)}'
         with engine.begin() as connection:
             connection.execute(sa.text(text))
 

--- a/sqlalchemy_utils/functions/foreign_keys.py
+++ b/sqlalchemy_utils/functions/foreign_keys.py
@@ -13,17 +13,15 @@ from .orm import _get_class_registry, get_column_key, get_mapper, get_tables
 
 def get_foreign_key_values(fk, obj):
     mapper = get_mapper(obj)
-    return dict(
-        (
-            fk.constraint.columns.values()[index],
-            getattr(obj, element.column.key)
-            if hasattr(obj, element.column.key)
-            else getattr(
-                obj, mapper.get_property_by_column(element.column).key
-            ),
+    return {
+        fk.constraint.columns.values()[index]:
+        getattr(obj, element.column.key)
+        if hasattr(obj, element.column.key)
+        else getattr(
+            obj, mapper.get_property_by_column(element.column).key
         )
         for index, element in enumerate(fk.constraint.elements)
-    )
+    }
 
 
 def group_foreign_keys(foreign_keys):
@@ -177,7 +175,7 @@ def merge_references(from_, to, foreign_keys=None):
                 fk.constraint.table.update()
                 .where(sa.and_(*criteria))
                 .values(
-                    dict((key.key, value) for key, value in new_values.items())
+                    {key.key: value for key, value in new_values.items()}
                 )
             )
             session.execute(query)

--- a/sqlalchemy_utils/functions/mock.py
+++ b/sqlalchemy_utils/functions/mock.py
@@ -37,7 +37,7 @@ def create_mock_engine(bind, stream=None):
                     elif isinstance(value, (datetime.date, datetime.datetime)):
                         return "'%s'" % value
 
-                    return super(Compiler, self).render_literal_value(
+                    return super().render_literal_value(
                         value, type_)
 
             text = str(Compiler(engine.dialect, sql).process(sql))

--- a/sqlalchemy_utils/functions/orm.py
+++ b/sqlalchemy_utils/functions/orm.py
@@ -72,14 +72,14 @@ def get_class_by_table(base, table, data=None):
     :param data: Data row to determine the class in polymorphic scenarios
     :return: Declarative class or None.
     """
-    found_classes = set(
+    found_classes = {
         c for c in _get_class_registry(base).values()
         if hasattr(c, '__table__') and c.__table__ is table
-    )
+    }
     if len(found_classes) > 1:
         if not data:
             raise ValueError(
-                "Multiple declarative classes found for table '{0}'. "
+                "Multiple declarative classes found for table '{}'. "
                 "Please provide data parameter for this function to be able "
                 "to determine polymorphic scenarios.".format(
                     table.name
@@ -93,7 +93,7 @@ def get_class_by_table(base, table, data=None):
                     if data[polymorphic_on] == mapper.polymorphic_identity:
                         return cls
             raise ValueError(
-                "Multiple declarative classes found for table '{0}'. Given "
+                "Multiple declarative classes found for table '{}'. Given "
                 "data row does not match any polymorphic identity of the "
                 "found classes.".format(
                     table.name
@@ -650,11 +650,11 @@ def get_hybrid_properties(model):
 
     :param model: SQLAlchemy declarative model or mapper
     """
-    return dict(
-        (key, prop)
+    return {
+        key: prop
         for key, prop in get_mapper(model).all_orm_descriptors.items()
         if isinstance(prop, hybrid_property)
-    )
+    }
 
 
 def get_declarative_base(model):

--- a/sqlalchemy_utils/generic.py
+++ b/sqlalchemy_utils/generic.py
@@ -97,7 +97,7 @@ class GenericRelationshipProperty(MapperProperty):
     """
 
     def __init__(self, discriminator, id, doc=None):
-        super(GenericRelationshipProperty, self).__init__()
+        super().__init__()
         self._discriminator_col = discriminator
         self._id_cols = id
         self._id = None

--- a/sqlalchemy_utils/i18n.py
+++ b/sqlalchemy_utils/i18n.py
@@ -59,7 +59,7 @@ class cast_locale_expr(ColumnElement):
 def compile_cast_locale_expr(element, compiler, **kw):
     locale = cast_locale(element.cls, element.locale, element.attr)
     if isinstance(locale, str):
-        return "'{0}'".format(locale)
+        return f"'{locale}'"
     return compiler.process(locale)
 
 

--- a/sqlalchemy_utils/models.py
+++ b/sqlalchemy_utils/models.py
@@ -51,7 +51,7 @@ def _generic_repr_method(self, fields):
             value = repr(value)
         field_reprs.append('='.join((key, value)))
 
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(field_reprs))
+    return '{}({})'.format(self.__class__.__name__, ', '.join(field_reprs))
 
 
 def generic_repr(*fields):

--- a/sqlalchemy_utils/path.py
+++ b/sqlalchemy_utils/path.py
@@ -19,14 +19,13 @@ class Path:
         return self.path.split(self.separator)
 
     def __iter__(self):
-        for part in self.parts:
-            yield part
+        yield from self.parts
 
     def __len__(self):
         return len(self.parts)
 
     def __repr__(self):
-        return "%s('%s')" % (self.__class__.__name__, self.path)
+        return f"{self.__class__.__name__}('{self.path}')"
 
     def index(self, element):
         return self.parts.index(element)
@@ -72,8 +71,7 @@ class AttrPath:
             self.parts.append(last_attr)
 
     def __iter__(self):
-        for part in self.parts:
-            yield part
+        yield from self.parts
 
     def __invert__(self):
         def get_backref(part):
@@ -138,7 +136,7 @@ class AttrPath:
         return len(self.path)
 
     def __repr__(self):
-        return "%s(%s, %r)" % (
+        return "{}({}, {!r})".format(
             self.__class__.__name__,
             self.class_.__name__,
             self.path.path

--- a/sqlalchemy_utils/primitives/country.py
+++ b/sqlalchemy_utils/primitives/country.py
@@ -60,7 +60,7 @@ class Country:
             self.code = code_or_country
         else:
             raise TypeError(
-                "Country() argument must be a string or a country, not '{0}'"
+                "Country() argument must be a string or a country, not '{}'"
                 .format(
                     type(code_or_country).__name__
                 )
@@ -76,7 +76,7 @@ class Country:
             i18n.babel.Locale('en').territories[code]
         except KeyError:
             raise ValueError(
-                'Could not convert string to country code: {0}'.format(code)
+                f'Could not convert string to country code: {code}'
             )
         except AttributeError:
             # As babel is optional, we may raise an AttributeError accessing it
@@ -104,7 +104,7 @@ class Country:
         return NotImplemented
 
     def __repr__(self):
-        return '%s(%r)' % (self.__class__.__name__, self.code)
+        return f'{self.__class__.__name__}({self.code!r})'
 
     def __unicode__(self):
         return self.name

--- a/sqlalchemy_utils/primitives/currency.py
+++ b/sqlalchemy_utils/primitives/currency.py
@@ -72,7 +72,7 @@ class Currency:
         try:
             i18n.babel.Locale('en').currencies[code]
         except KeyError:
-            raise ValueError("'{0}' is not valid currency code.".format(code))
+            raise ValueError(f"'{code}' is not valid currency code.")
         except AttributeError:
             # As babel is optional, we may raise an AttributeError accessing it
             pass
@@ -103,7 +103,7 @@ class Currency:
         return hash(self.code)
 
     def __repr__(self):
-        return '%s(%r)' % (self.__class__.__name__, self.code)
+        return f'{self.__class__.__name__}({self.code!r})'
 
     def __unicode__(self):
         return self.code

--- a/sqlalchemy_utils/primitives/ltree.py
+++ b/sqlalchemy_utils/primitives/ltree.py
@@ -100,7 +100,7 @@ class Ltree:
             self.path = path_or_ltree
         else:
             raise TypeError(
-                "Ltree() argument must be a string or an Ltree, not '{0}'"
+                "Ltree() argument must be a string or an Ltree, not '{}'"
                 .format(
                     type(path_or_ltree).__name__
                 )
@@ -110,7 +110,7 @@ class Ltree:
     def validate(cls, path):
         if path_matcher.match(path) is None:
             raise ValueError(
-                "'{0}' is not a valid ltree path.".format(path)
+                f"'{path}' is not a valid ltree path."
             )
 
     def __len__(self):
@@ -152,7 +152,7 @@ class Ltree:
         elif isinstance(key, slice):
             return Ltree('.'.join(self.path.split('.')[key]))
         raise TypeError(
-            'Ltree indices must be integers, not {0}'.format(
+            'Ltree indices must be integers, not {}'.format(
                 key.__class__.__name__
             )
         )
@@ -168,12 +168,12 @@ class Ltree:
         other_parts = [Ltree(other).path.split('.') for other in others]
         parts = self.path.split('.')
         for index, element in enumerate(parts):
-            if any((
+            if any(
                 other[index] != element or
                 len(other) <= index + 1 or
                 len(parts) == index + 1
                 for other in other_parts
-            )):
+            ):
                 if index == 0:
                     return None
                 return Ltree('.'.join(parts[0:index]))
@@ -199,7 +199,7 @@ class Ltree:
         return not (self == other)
 
     def __repr__(self):
-        return '%s(%r)' % (self.__class__.__name__, self.path)
+        return f'{self.__class__.__name__}({self.path!r})'
 
     def __unicode__(self):
         return self.path

--- a/sqlalchemy_utils/primitives/weekday.py
+++ b/sqlalchemy_utils/primitives/weekday.py
@@ -29,7 +29,7 @@ class WeekDay:
         return self.position < other.position
 
     def __repr__(self):
-        return '%s(%r)' % (self.__class__.__name__, self.index)
+        return f'{self.__class__.__name__}({self.index!r})'
 
     def __unicode__(self):
         return self.name

--- a/sqlalchemy_utils/primitives/weekdays.py
+++ b/sqlalchemy_utils/primitives/weekdays.py
@@ -10,7 +10,7 @@ class WeekDays:
 
             if len(bit_string_or_week_days) != WeekDay.NUM_WEEK_DAYS:
                 raise ValueError(
-                    'Bit string must be {0} characters long.'.format(
+                    'Bit string must be {} characters long.'.format(
                         WeekDay.NUM_WEEK_DAYS
                     )
                 )
@@ -36,14 +36,13 @@ class WeekDays:
             return NotImplemented
 
     def __iter__(self):
-        for day in sorted(self._days):
-            yield day
+        yield from sorted(self._days)
 
     def __contains__(self, value):
         return value in self._days
 
     def __repr__(self):
-        return '%s(%r)' % (
+        return '{}({!r})'.format(
             self.__class__.__name__,
             self.as_bit_string()
         )

--- a/sqlalchemy_utils/types/arrow.py
+++ b/sqlalchemy_utils/types/arrow.py
@@ -55,7 +55,7 @@ class ArrowType(EnrichedDateTimeType):
                 "'arrow' package is required to use 'ArrowType'"
             )
 
-        super(ArrowType, self).__init__(
+        super().__init__(
             datetime_processor=ArrowDateTime,
             *args,
             **kwargs

--- a/sqlalchemy_utils/types/color.py
+++ b/sqlalchemy_utils/types/color.py
@@ -60,7 +60,7 @@ class ColorType(ScalarCoercible, types.TypeDecorator):
                 "'colour' package is required to use 'ColorType'"
             )
 
-        super(ColorType, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.impl = types.Unicode(max_length)
 
     def process_bind_param(self, value, dialect):

--- a/sqlalchemy_utils/types/currency.py
+++ b/sqlalchemy_utils/types/currency.py
@@ -56,7 +56,7 @@ class CurrencyType(ScalarCoercible, types.TypeDecorator):
                 "'babel' package is required in order to use CurrencyType."
             )
 
-        super(CurrencyType, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def process_bind_param(self, value, dialect):
         if isinstance(value, Currency):

--- a/sqlalchemy_utils/types/email.py
+++ b/sqlalchemy_utils/types/email.py
@@ -36,7 +36,7 @@ class EmailType(sa.types.TypeDecorator):
     cache_ok = True
 
     def __init__(self, length=255, *args, **kwargs):
-        super(EmailType, self).__init__(length=length, *args, **kwargs)
+        super().__init__(length=length, *args, **kwargs)
 
     def process_bind_param(self, value, dialect):
         if value is not None:

--- a/sqlalchemy_utils/types/encrypted/encrypted_type.py
+++ b/sqlalchemy_utils/types/encrypted/encrypted_type.py
@@ -365,7 +365,7 @@ class StringEncryptedType(TypeDecorator, ScalarCoercible):
             raise ImproperlyConfigured(
                 "'cryptography' is required to use EncryptedType"
             )
-        super(StringEncryptedType, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         # set the underlying type
         if type_in is None:
             type_in = String()

--- a/sqlalchemy_utils/types/enriched_datetime/enriched_date_type.py
+++ b/sqlalchemy_utils/types/enriched_datetime/enriched_date_type.py
@@ -30,7 +30,7 @@ class EnrichedDateType(types.TypeDecorator, ScalarCoercible):
     cache_ok = True
 
     def __init__(self, date_processor=PendulumDate, *args, **kwargs):
-        super(EnrichedDateType, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.date_object = date_processor()
 
     def _coerce(self, value):

--- a/sqlalchemy_utils/types/enriched_datetime/enriched_datetime_type.py
+++ b/sqlalchemy_utils/types/enriched_datetime/enriched_datetime_type.py
@@ -31,7 +31,7 @@ class EnrichedDateTimeType(types.TypeDecorator, ScalarCoercible):
     cache_ok = True
 
     def __init__(self, datetime_processor=PendulumDateTime, *args, **kwargs):
-        super(EnrichedDateTimeType, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.dt_object = datetime_processor()
 
     def _coerce(self, value):

--- a/sqlalchemy_utils/types/enriched_datetime/pendulum_date.py
+++ b/sqlalchemy_utils/types/enriched_datetime/pendulum_date.py
@@ -18,7 +18,7 @@ class PendulumDate(PendulumDateTime):
     def _coerce(self, impl, value):
         if value:
             if not isinstance(value, pendulum.Date):
-                value = super(PendulumDate, self)._coerce(impl, value).date()
+                value = super()._coerce(impl, value).date()
         return value
 
     def process_result_value(self, impl, value, dialect):

--- a/sqlalchemy_utils/types/ip_address.py
+++ b/sqlalchemy_utils/types/ip_address.py
@@ -35,7 +35,7 @@ class IPAddressType(ScalarCoercible, types.TypeDecorator):
     cache_ok = True
 
     def __init__(self, max_length=50, *args, **kwargs):
-        super(IPAddressType, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.impl = types.Unicode(max_length)
 
     def process_bind_param(self, value, dialect):

--- a/sqlalchemy_utils/types/json.py
+++ b/sqlalchemy_utils/types/json.py
@@ -50,7 +50,7 @@ class JSONType(sa.types.TypeDecorator):
     cache_ok = True
 
     def __init__(self, *args, **kwargs):
-        super(JSONType, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def load_dialect_impl(self, dialect):
         if dialect.name == 'postgresql':

--- a/sqlalchemy_utils/types/password.py
+++ b/sqlalchemy_utils/types/password.py
@@ -15,7 +15,7 @@ except ImportError:
     pass
 
 
-class Password(Mutable, object):
+class Password(Mutable):
 
     @classmethod
     def coerce(cls, key, value):
@@ -25,7 +25,7 @@ class Password(Mutable, object):
         if isinstance(value, (str, bytes)):
             return cls(value, secret=True)
 
-        super(Password, cls).coerce(key, value)
+        super().coerce(key, value)
 
     def __init__(self, value, context=None, secret=False):
         # Store the hash (if it is one).

--- a/sqlalchemy_utils/types/pg_composite.py
+++ b/sqlalchemy_utils/types/pg_composite.py
@@ -147,12 +147,12 @@ class CompositeElement(FunctionElement):
         self.name = field
         self.type = to_instance(type_)
 
-        super(CompositeElement, self).__init__(base)
+        super().__init__(base)
 
 
 @compiles(CompositeElement)
 def _compile_pgelem(expr, compiler, **kw):
-    return '(%s).%s' % (compiler.process(expr.clauses, **kw), expr.name)
+    return f'({compiler.process(expr.clauses, **kw)}).{expr.name}'
 
 
 # TODO: Make the registration work on connection level instead of global level
@@ -176,7 +176,7 @@ class CompositeType(UserDefinedType, SchemaType):
                 type_ = self.type.typemap[key]
             except KeyError:
                 raise KeyError(
-                    "Type '%s' doesn't have an attribute: '%s'" % (
+                    "Type '{}' doesn't have an attribute: '{}'".format(
                         self.name, key
                     )
                 )
@@ -297,7 +297,7 @@ def register_psycopg2_composite(dbapi_connection, composite):
             for value in adapted
         ]
         return AsIs(
-            '(%s)::%s' % (
+            '({})::{}'.format(
                 ', '.join(values),
                 dialect.identifier_preparer.quote(composite.name)
             )
@@ -379,4 +379,4 @@ class DropCompositeType(_CreateDropBase):
 def _visit_drop_composite_type(drop, compiler, **kw):
     type_ = drop.element
 
-    return 'DROP TYPE {name}'.format(name=compiler.preparer.format_type(type_))
+    return f'DROP TYPE {compiler.preparer.format_type(type_)}'

--- a/sqlalchemy_utils/types/phone_number.py
+++ b/sqlalchemy_utils/types/phone_number.py
@@ -106,7 +106,7 @@ class PhoneNumber(BasePhoneNumber):
             # bindings need to be updated.
             raise PhoneNumberParseException(getattr(e, "error_type", -1), str(e))
 
-        super(PhoneNumber, self).__init__(
+        super().__init__(
             country_code=self._phone_number.country_code,
             national_number=self._phone_number.national_number,
             extension=self._phone_number.extension,
@@ -176,7 +176,7 @@ class PhoneNumberType(ScalarCoercible, types.TypeDecorator):
                 "The 'phonenumbers' package is required to use 'PhoneNumberType'"
             )
 
-        super(PhoneNumberType, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.region = region
         self.impl = types.Unicode(max_length)
 
@@ -186,7 +186,7 @@ class PhoneNumberType(ScalarCoercible, types.TypeDecorator):
                 value = PhoneNumber(value, region=self.region)
 
             if self.STORE_FORMAT == "e164" and value.extension:
-                return "%s;ext=%s" % (value.e164, value.extension)
+                return f"{value.e164};ext={value.extension}"
 
             return getattr(value, self.STORE_FORMAT)
 

--- a/sqlalchemy_utils/types/range.py
+++ b/sqlalchemy_utils/types/range.py
@@ -185,7 +185,7 @@ class RangeComparator(types.TypeEngine.Comparator):
             not isinstance(other, str)
         ):
             other = map(self.coerce_arg, other)
-        return super(RangeComparator, self).in_(other)
+        return super().in_(other)
 
     def notin_(self, other):
         if (
@@ -193,7 +193,7 @@ class RangeComparator(types.TypeEngine.Comparator):
             not isinstance(other, str)
         ):
             other = map(self.coerce_arg, other)
-        return super(RangeComparator, self).notin_(other)
+        return super().notin_(other)
 
     def __rshift__(self, other, **kwargs):
         """
@@ -271,7 +271,7 @@ class RangeType(ScalarCoercible, types.TypeDecorator):
                 'RangeType needs intervals package installed.'
             )
         self.step = kwargs.pop('step', None)
-        super(RangeType, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def load_dialect_impl(self, dialect):
         if dialect.name == 'postgresql':
@@ -358,7 +358,7 @@ class IntRangeType(RangeType):
     cache_ok = True
 
     def __init__(self, *args, **kwargs):
-        super(IntRangeType, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.interval_class = intervals.IntInterval
 
 
@@ -411,7 +411,7 @@ class Int8RangeType(RangeType):
     cache_ok = True
 
     def __init__(self, *args, **kwargs):
-        super(Int8RangeType, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.interval_class = intervals.IntInterval
 
 
@@ -438,7 +438,7 @@ class DateRangeType(RangeType):
     cache_ok = True
 
     def __init__(self, *args, **kwargs):
-        super(DateRangeType, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.interval_class = intervals.DateInterval
 
 
@@ -466,7 +466,7 @@ class NumericRangeType(RangeType):
     cache_ok = True
 
     def __init__(self, *args, **kwargs):
-        super(NumericRangeType, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.interval_class = intervals.DecimalInterval
 
 
@@ -476,5 +476,5 @@ class DateTimeRangeType(RangeType):
     cache_ok = True
 
     def __init__(self, *args, **kwargs):
-        super(DateTimeRangeType, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.interval_class = intervals.DateTimeInterval

--- a/sqlalchemy_utils/types/ts_vector.py
+++ b/sqlalchemy_utils/types/ts_vector.py
@@ -105,4 +105,4 @@ class TSVectorType(sa.types.TypeDecorator):
         """
         self.columns = args
         self.options = kwargs
-        super(TSVectorType, self).__init__()
+        super().__init__()

--- a/sqlalchemy_utils/types/uuid.py
+++ b/sqlalchemy_utils/types/uuid.py
@@ -74,7 +74,7 @@ class UUIDType(ScalarCoercible, types.TypeDecorator):
     # It is only necessary to quote UUID's in sqlalchemy < 1.4.30.
     if sqlalchemy_version < (1, 4, 30):
         def process_literal_param(self, value, dialect):
-            return "'{}'".format(value) if value else value
+            return f"'{value}'" if value else value
     else:
         def process_literal_param(self, value, dialect):
             return value

--- a/sqlalchemy_utils/types/weekdays.py
+++ b/sqlalchemy_utils/types/weekdays.py
@@ -58,7 +58,7 @@ class WeekDaysType(types.TypeDecorator, ScalarCoercible):
                 "'babel' package is required to use 'WeekDaysType'"
             )
 
-        super(WeekDaysType, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     @property
     def comparator_factory(self):

--- a/tests/functions/test_database.py
+++ b/tests/functions/test_database.py
@@ -66,7 +66,7 @@ class TestDatabasePostgres(DatabaseTest):
         return 'db_test_sqlalchemy_util'
 
     def test_template(self, postgresql_db_user, postgresql_db_password):
-        dsn = 'postgresql://{0}:{1}@localhost/db_test_sqlalchemy_util'.format(
+        dsn = 'postgresql://{}:{}@localhost/db_test_sqlalchemy_util'.format(
             postgresql_db_user,
             postgresql_db_password
         )
@@ -80,7 +80,7 @@ class TestDatabasePostgresPg8000(DatabaseTest):
 
     @pytest.fixture
     def dsn(self, postgresql_db_user, postgresql_db_password):
-        return 'postgresql+pg8000://{0}:{1}@localhost/{2}'.format(
+        return 'postgresql+pg8000://{}:{}@localhost/{}'.format(
             postgresql_db_user,
             postgresql_db_password,
             'db_to_test_create_and_drop_via_pg8000_driver'
@@ -91,7 +91,7 @@ class TestDatabasePostgresPsycoPG2CFFI(DatabaseTest):
 
     @pytest.fixture
     def dsn(self, postgresql_db_user, postgresql_db_password):
-        return 'postgresql+psycopg2cffi://{0}:{1}@localhost/{2}'.format(
+        return 'postgresql+psycopg2cffi://{}:{}@localhost/{}'.format(
             postgresql_db_user,
             postgresql_db_password,
             'db_to_test_create_and_drop_via_psycopg2cffi_driver'
@@ -106,7 +106,7 @@ class TestDatabasePostgresWithQuotedName(DatabaseTest):
         return 'db_test_sqlalchemy-util'
 
     def test_template(self, postgresql_db_user, postgresql_db_password):
-        dsn = 'postgresql://{0}:{1}@localhost/db_test_sqlalchemy-util'.format(
+        dsn = 'postgresql://{}:{}@localhost/db_test_sqlalchemy-util'.format(
             postgresql_db_user,
             postgresql_db_password
         )
@@ -123,11 +123,11 @@ class TestDatabasePostgresCreateDatabaseCloseConnection:
         postgresql_db_password
     ):
         dsn_list = [
-            'postgresql://{0}:{1}@localhost/db_test_sqlalchemy-util-a'.format(
+            'postgresql://{}:{}@localhost/db_test_sqlalchemy-util-a'.format(
                 postgresql_db_user,
                 postgresql_db_password
             ),
-            'postgresql://{0}:{1}@localhost/db_test_sqlalchemy-util-b'.format(
+            'postgresql://{}:{}@localhost/db_test_sqlalchemy-util-b'.format(
                 postgresql_db_user,
                 postgresql_db_password
             ),

--- a/tests/functions/test_get_referencing_foreign_keys.py
+++ b/tests/functions/test_get_referencing_foreign_keys.py
@@ -101,4 +101,4 @@ class TestGetReferencingFksWithInheritance:
 
     def test_with_table(self, Admin):
         fks = get_referencing_foreign_keys(Admin.__table__)
-        assert fks == set([])
+        assert fks == set()

--- a/tests/primitives/test_currency.py
+++ b/tests/primitives/test_currency.py
@@ -16,7 +16,7 @@ class TestCurrency:
         assert Currency('USD') == Currency(Currency('USD'))
 
     def test_hashability(self):
-        assert len(set([Currency('USD'), Currency('USD')])) == 1
+        assert len({Currency('USD'), Currency('USD')}) == 1
 
     def test_invalid_currency_code(self):
         with pytest.raises(ValueError):

--- a/tests/primitives/test_ltree.py
+++ b/tests/primitives/test_ltree.py
@@ -47,7 +47,7 @@ class TestLtree:
         with pytest.raises(ValueError) as e:
             Ltree.validate(path)
         assert str(e.value) == (
-            "'{0}' is not a valid ltree path.".format(path)
+            f"'{path}' is not a valid ltree path."
         )
 
     @pytest.mark.parametrize(

--- a/tests/primitives/test_weekdays.py
+++ b/tests/primitives/test_weekdays.py
@@ -89,7 +89,7 @@ class TestWeekDay:
 class TestWeekDays:
     def test_constructor_with_valid_bit_string(self):
         days = WeekDays('1000100')
-        assert days._days == set([WeekDay(0), WeekDay(4)])
+        assert days._days == {WeekDay(0), WeekDay(4)}
 
     @pytest.mark.parametrize(
         'bit_string',

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -79,5 +79,5 @@ class TestGenericRepr:
         article = session.query(Article).options(sa.orm.defer(Article.name)).one()
         actual_repr = repr(article)
 
-        expected_repr = 'Article(id={}, name=<not loaded>)'.format(article.id)
+        expected_repr = f'Article(id={article.id}, name=<not loaded>)'
         assert actual_repr == expected_repr

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -147,7 +147,7 @@ class SupportsCascade(TrivialViewTestCases):
 class DoesntSupportCascade(SupportsCascade):
     @pytest.mark.xfail
     def test_life_cycle_cascade(self, *args, **kwargs):
-        super(DoesntSupportCascade, self).test_life_cycle_cascade(
+        super().test_life_cycle_cascade(
             *args,
             **kwargs
         )

--- a/tests/types/test_choice.py
+++ b/tests/types/test_choice.py
@@ -115,7 +115,7 @@ class TestEnumType:
             )
 
             def __repr__(self):
-                return 'Order(%r, %r)' % (self.id_, self.status)
+                return f'Order({self.id_!r}, {self.status!r})'
 
         return Order
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
     py{36, 37, 38, 39, 310, 311}-sqlalchemy{13, 14}
-    lint
+    flake8
+    isort
 
 [testenv]
 commands =
@@ -29,16 +30,17 @@ passenv =
     SQLALCHEMY_UTILS_TEST_*
 recreate = True
 
-[testenv:lint]
-recreate = True
-commands =
-    flake8 .
-    isort --verbose --diff .
-    isort --verbose --check-only .
+[testenv:flake8]
 skip_install = True
-deps =
-    flake8
-    isort
+recreate = False
+deps = pre-commit
+commands = pre-commit run --hook-stage manual --all flake8
+
+[testenv:isort]
+skip_install = True
+recreate = False
+deps = pre-commit
+commands = pre-commit run --hook-stage manual --all isort-check
 
 [pytest]
 filterwarnings =


### PR DESCRIPTION
This PR introduces pre-commit:

* Pre-commit hooks for isort, flake8, and pyupgrade (in Python 3.6 syntax mode), as well as basic text linting, are introduced.
* Tox now runs pre-commit to execute the linters so the test suite linters and pre-commit checks are always using the same tool versions.
* Pyupgrade was run against the codebase, which primarily resulted in the use of f-strings throughout the codebase (instances of `"%s %s" % (x, y)` and `"{0} {1}".format(x, y)` were all replaced with `f"{x} {y}"`).
* The GitHub CI lint check was upgraded to suppress warnings about Node 12.