### PR TITLE
add changelog entry in 0.38.3 about dropped Pyhton 3.4/3.5

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,7 @@ Unreleased
 - Fixed create_database() and drop_database() crashing with CockroachDB (#586, pull request courtesy of kurtmckee)
 - Added mixed case support for pg composite (#584, pull request courtesy of bamartin125)
 - Support Python 3.10.
+- Drop support for Python 3.4 and 3.5.
 - Remove the dependency on the six package. (#605)
 - Introduce sqlalchemy 2.0 compatibility. (#513)
 


### PR DESCRIPTION
The change was introduced in 0.38.3 (in https://github.com/kvesteri/sqlalchemy-utils/commit/51464b68342c0462aa833ad507e91f0024e45293) by dropping Python 3.4/3.5 support while adding 3.10, but it wasn't reported.
