### PR TITLE
DRAFT: Update `create_database` and `get_bind` for sqlalchemy v2 beta

### DIFF
--- a/sqlalchemy_utils/aggregates.py
+++ b/sqlalchemy_utils/aggregates.py
@@ -509,7 +509,7 @@ class AggregationManager:
 
     def register_listeners(self):
         sa.event.listen(
-            sa.orm.mapper,
+            sa.orm.Mapper,
             'after_configured',
             self.update_generator_registry
         )

--- a/sqlalchemy_utils/proxy_dict.py
+++ b/sqlalchemy_utils/proxy_dict.py
@@ -81,4 +81,4 @@ def expire_proxy_dicts(target, context):
         target._proxy_dicts = {}
 
 
-sa.event.listen(sa.orm.mapper, 'expire', expire_proxy_dicts)
+sa.event.listen(sa.orm.Mapper, 'expire', expire_proxy_dicts)


### PR DESCRIPTION
SQLalchemy plan on releasing v2.0 of their software in the next week. 

`create_database` and `get_bind` for quite integral part of the `sqlalchemy-utils` library and this is my attempted help in addressing the issue as soonest. 

I'm quite noob, so don't exactly know how to fix the underlying issue, but this is a starting point for the upgrade to support v2. 

If someone could kindly give me some guidance, I'd happily try and address the underlying issues.

DRAFT fix #669  