### PR TITLE
fix: handle engine objects in quote func for SQLAlchemy 2 compatibility

### DIFF
--- a/sqlalchemy_utils/functions/orm.py
+++ b/sqlalchemy_utils/functions/orm.py
@@ -524,6 +524,8 @@ def quote(mixed, ident):
     """
     if isinstance(mixed, Dialect):
         dialect = mixed
+    elif hasattr(mixed, 'dialect'):
+        dialect = mixed.dialect
     else:
         dialect = get_bind(mixed).dialect
     return dialect.preparer(dialect).quote(ident)


### PR DESCRIPTION
With SQLAlchemy 2.0 and postgres, 'create_database()'' function from sqlalchemy-utils was failing and the issue was caused by the failure of the quote() function to determine the dialect of the database driver. This was due to the removal of the direct engine.execute() calls in SQLAlchemy 2.0 which caused the get_bind() function to fail in case of Engine object.

This change adds a check in the quote() function to see if the input is an engine object. If it is, the dialect attribute is used directly instead of trying to use the get_bind() function.
This resolves the issue with create_database()
where the get_bind() function was not able to return a bind for the engine object and the subsequent failure of the quote() function.

This change allows the 'create_database()'' function from the sqlalchemy-utils library to be compatible with SQLAlchemy 2.0.0

Fixes #676