### PR TITLE
feat: more SA 2.0 fixes

### DIFF
--- a/sqlalchemy_utils/observer.py
+++ b/sqlalchemy_utils/observer.py
@@ -189,12 +189,12 @@ class PropertyObserver:
     def __init__(self):
         self.listener_args = [
             (
-                sa.orm.mapper,
+                sa.orm.Mapper,
                 'mapper_configured',
                 self.update_generator_registry
             ),
             (
-                sa.orm.mapper,
+                sa.orm.Mapper,
                 'after_configured',
                 self.gather_paths
             ),

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -1,6 +1,5 @@
 import pytest
 import sqlalchemy as sa
-from sqlalchemy.util.langhelpers import symbol
 
 from sqlalchemy_utils.path import AttrPath, Path
 
@@ -54,9 +53,7 @@ class TestAttrPath:
         pass
 
     def test_direction(self, SubSection):
-        assert (
-            AttrPath(SubSection, 'section').direction == symbol('MANYTOONE')
-        )
+        assert AttrPath(SubSection, 'section').direction.name == 'MANYTOONE'
 
     def test_invert(self, Document, Section, SubSection):
         path = ~ AttrPath(SubSection, 'section.document')


### PR DESCRIPTION
* Get rid of symbol reference
* Use sa.orm.Mapper instead of sa.orm.mapper