### PR TITLE
fix: make tests SA 2.0 compatible

### DIFF
--- a/tests/functions/test_get_columns.py
+++ b/tests/functions/test_get_columns.py
@@ -19,11 +19,8 @@ def columns():
 
 
 class TestGetColumns:
-    def test_table(self, Building):
-        assert isinstance(
-            get_columns(Building.__table__),
-            sa.sql.base.ImmutableColumnCollection
-        )
+    def test_table(self, Building, columns):
+        assert [c.name for c in get_columns(Building.__table__)] == columns
 
     def test_instrumented_attribute(self, Building):
         assert get_columns(Building.id) == [Building.__table__.c._id]

--- a/tests/functions/test_get_referencing_foreign_keys.py
+++ b/tests/functions/test_get_referencing_foreign_keys.py
@@ -5,7 +5,6 @@ from sqlalchemy_utils import get_referencing_foreign_keys
 
 
 class TestGetReferencingFksWithCompositeKeys:
-
     @pytest.fixture
     def User(self, Base):
         class User(Base):
@@ -65,6 +64,9 @@ class TestGetReferencingFksWithInheritance:
             id = sa.Column(
                 sa.Integer, sa.ForeignKey(User.id), primary_key=True
             )
+            __mapper_args__ = {
+                'polymorphic_identity': 'admin'
+            }
         return Admin
 
     @pytest.fixture


### PR DESCRIPTION
Make get_columns and get_referencing_foreign_keys tests SQLAlchemy 2.0 compatible.