### PR TITLE
feat: make merge_references SA 2.0 compatible

### DIFF
--- a/tests/functions/test_merge_references.py
+++ b/tests/functions/test_merge_references.py
@@ -61,6 +61,7 @@ class TestMergeReferences:
         # Load the author for post
         assert post.author_id == john.id
         merge_references(john, jack)
+        session.commit()
         assert post.author_id == jack.id
         assert post2.author_id == jack.id
 


### PR DESCRIPTION
Only allow SQL-based merging for merge_references. Previously this function also allowed synchronize_session based ORM merging but this is no longer possible in SA 2.0.