### PR TITLE
Add psycopg3 support for database functions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ extras_require = {
         'Jinja2>=2.3',
         'docutils>=0.10',
         'flexmock>=0.9.7',
+        'psycopg>=3.1.8',
         'psycopg2>=2.5.1',
         'psycopg2cffi>=2.8.1',
         'pg8000>=1.12.4',

--- a/sqlalchemy_utils/functions/database.py
+++ b/sqlalchemy_utils/functions/database.py
@@ -556,7 +556,7 @@ def create_database(url, encoding='utf8', template=None):
 
     if (dialect_name == 'mssql' and dialect_driver in {'pymssql', 'pyodbc'}) \
             or (dialect_name == 'postgresql' and dialect_driver in {
-            'asyncpg', 'pg8000', 'psycopg2', 'psycopg2cffi'}):
+            'asyncpg', 'pg8000', 'psycopg', 'psycopg2', 'psycopg2cffi'}):
         engine = sa.create_engine(url, isolation_level='AUTOCOMMIT')
     else:
         engine = sa.create_engine(url)
@@ -625,7 +625,7 @@ def drop_database(url):
     if dialect_name == 'mssql' and dialect_driver in {'pymssql', 'pyodbc'}:
         engine = sa.create_engine(url, connect_args={'autocommit': True})
     elif dialect_name == 'postgresql' and dialect_driver in {
-            'asyncpg', 'pg8000', 'psycopg2', 'psycopg2cffi'}:
+            'asyncpg', 'pg8000', 'psycopg', 'psycopg2', 'psycopg2cffi'}:
         engine = sa.create_engine(url, isolation_level='AUTOCOMMIT')
     else:
         engine = sa.create_engine(url)

--- a/tests/functions/test_database.py
+++ b/tests/functions/test_database.py
@@ -2,12 +2,15 @@ import pytest
 import sqlalchemy as sa
 
 from sqlalchemy_utils import create_database, database_exists, drop_database
+from sqlalchemy_utils.compat import get_sqlalchemy_version
 
 pymysql = None
 try:
     import pymysql  # noqa
 except ImportError:
     pass
+
+sqlalchemy_version = get_sqlalchemy_version()
 
 
 class DatabaseTest:
@@ -98,6 +101,7 @@ class TestDatabasePostgresPsycoPG2CFFI(DatabaseTest):
         )
 
 
+@pytest.mark.skipif('sqlalchemy_version < (2, 0, 0)')
 class TestDatabasePostgresPsycoPG3(DatabaseTest):
 
     @pytest.fixture

--- a/tests/functions/test_database.py
+++ b/tests/functions/test_database.py
@@ -98,6 +98,17 @@ class TestDatabasePostgresPsycoPG2CFFI(DatabaseTest):
         )
 
 
+class TestDatabasePostgresPsycoPG3(DatabaseTest):
+
+    @pytest.fixture
+    def dsn(self, postgresql_db_user, postgresql_db_password):
+        return 'postgresql+psycopg://{}:{}@localhost/{}'.format(
+            postgresql_db_user,
+            postgresql_db_password,
+            'db_to_test_create_and_drop_via_psycopg3_driver'
+        )
+
+
 @pytest.mark.usefixtures('postgresql_dsn')
 class TestDatabasePostgresWithQuotedName(DatabaseTest):
 


### PR DESCRIPTION
Sqlalchemy now supports psycopg3, that is called simply psycopg and create(delete)_database functions do not detect this dialect properly