### PR TITLE
Update generic.py to be able to access the generic_relationship after the session ends

### DIFF
--- a/sqlalchemy_utils/generic.py
+++ b/sqlalchemy_utils/generic.py
@@ -41,6 +41,8 @@ class GenericAttributeImpl(attributes.ScalarAttributeImpl):
             # sqlalchemy 1.3
             target = session.query(target_class).get(id)
 
+        # Cache result for after session expires
+        dict_[self.key] = target
         # Return found (or not found) target.
         return target
 


### PR DESCRIPTION
Add caching of the attribute retrial for generic relationships so that the attribute is accessible after the session expires