### PR TITLE
Update GenericAttributeImpl to work with SqlAlchemy 2.0.22

### DIFF
--- a/sqlalchemy_utils/generic.py
+++ b/sqlalchemy_utils/generic.py
@@ -13,6 +13,13 @@ from .functions.orm import _get_class_registry
 
 
 class GenericAttributeImpl(attributes.ScalarAttributeImpl):
+    def __init__(self, *args, **kwargs):
+        # arguments received (class, key, dispatch)
+        # The attributes.AttributeImpl requires (class, key, default_function, dispatch)
+        # Setting None as default_function here
+        args = args[:2] + (None, ) + args[2:]
+        super().__init__(*args, **kwargs)
+
     def get(self, state, dict_, passive=attributes.PASSIVE_OFF):
         if self.key in dict_:
             return dict_[self.key]


### PR DESCRIPTION
This change fixes the issue, but I'm not sure if this should be fixed in SQLAlchemy directly.

I've been debugging and found the problem in this call where there's a missing parameter. Looks like the `AttributeImpl` class now requires [4 positional parameters](https://github.com/sqlalchemy/sqlalchemy/blob/main/lib/sqlalchemy/orm/attributes.py#L838), and the [register_attribute mapping is not calling this](https://github.com/sqlalchemy/sqlalchemy/blob/main/lib/sqlalchemy/orm/attributes.py#L2620-L2622) correctly.

Fix https://github.com/kvesteri/sqlalchemy-utils/issues/719