### PR TITLE
Skip aggregator processing when none have been registered

### DIFF
--- a/sqlalchemy_utils/aggregates.py
+++ b/sqlalchemy_utils/aggregates.py
@@ -534,6 +534,10 @@ class AggregationManager:
                 )
 
     def construct_aggregate_queries(self, session, ctx):
+        if not self.generator_registry:
+            # short-circuit looping through objects if there are no aggregates defined
+            return
+
         object_dict = defaultdict(list)
         for obj in session:
             for class_ in self.generator_registry:


### PR DESCRIPTION
As noted in #700, we noticed the overhead of `construct_aggregate_queries()` looping through all the objects in the session, even if there were no aggregates defined.  Thus, this short-circuits that process if there are no aggregators registered.