### PR TITLE
fix: use back_populates is backref is not there

### DIFF
--- a/sqlalchemy_utils/listeners.py
+++ b/sqlalchemy_utils/listeners.py
@@ -241,7 +241,7 @@ def auto_delete_orphans(attr):
     parent_class = attr.parent.class_
     target_class = attr.property.mapper.class_
 
-    backref = attr.property.backref
+    backref = attr.property.backref or attr.property.back_populates
     if not backref:
         raise ImproperlyConfigured(
             'The relationship argument given for auto_delete_orphans needs to '


### PR DESCRIPTION
Since back_populates is preferred, use it if backref is not populated. It's my understanding that they both have the same value, it's just back_populates needs to be on both sides.

I haven't touched the tests yet, but this seems to work OK for my application. 

Happy to put some effort into the tests if this is agreement on this approach.