### PR TITLE
Fix: TranslationHybrid setter_factory not persisting changes

### DIFF
--- a/sqlalchemy_utils/i18n.py
+++ b/sqlalchemy_utils/i18n.py
@@ -98,6 +98,7 @@ class TranslationHybrid:
                 setattr(obj, attr.key, {})
             locale = cast_locale(obj, self.current_locale, attr)
             getattr(obj, attr.key)[locale] = value
+            sa.orm.attributes.flag_modified(obj, attr.key)
         return setter
 
     def expr_factory(self, attr):


### PR DESCRIPTION
Marks the attribute in the setter factory as dirty so SQLAlchemy includes the changes in the next commit.

Currently without this, running `session.commit()` followed by `session.refresh(model)` does not persist changes to the model translation hybrid field updated.

Tested with SQLAlchemy version 1.4.37

