### PR TITLE
Support hyphens in `ltree` paths

### DIFF
--- a/sqlalchemy_utils/primitives/ltree.py
+++ b/sqlalchemy_utils/primitives/ltree.py
@@ -2,7 +2,7 @@ import re
 
 from ..utils import str_coercible
 
-path_matcher = re.compile(r'^[A-Za-z0-9_]+(\.[A-Za-z0-9_]+)*$')
+path_matcher = re.compile(r'^[A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+)*$')
 
 
 @str_coercible


### PR DESCRIPTION
Adds support for hyphens in `ltree` paths. Here is the [source](https://www.postgresql.org/docs/current/ltree.html#LTREE-DEFINITIONS) on postgresql.org, showing that's valid.

Without this, Ltrees with `-` incorrectly fail the path matcher.