### PR TITLE
Upgrading msodbcsql to msodbcsql18

### DIFF
--- a/.ci/install_mssql.sh
+++ b/.ci/install_mssql.sh
@@ -6,4 +6,4 @@ if [ ! -f /etc/apt/sources.list.d/microsoft-prod.list ]; then
 fi
 
 sudo apt-get update
-sudo ACCEPT_EULA=Y apt-get -y install msodbcsql17 unixodbc
+sudo ACCEPT_EULA=Y apt-get -y install msodbcsql18 unixodbc

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,11 +12,6 @@ jobs:
           - '3.11'
           - '3.12'
         tox_env: ['sqlalchemy14', 'sqlalchemy2']
-        include:
-          # Test against Python 3.9 and sqlalchemy 1.4
-          - os: 'ubuntu-20.04'
-            python-version: '3.9'
-            tox_env: 'sqlalchemy14'
     runs-on: ${{ matrix.os }}
     services:
       postgres:

--- a/conftest.py
+++ b/conftest.py
@@ -110,13 +110,13 @@ def mssql_db_password():
 @pytest.fixture
 def mssql_db_driver():
     driver = os.environ.get('SQLALCHEMY_UTILS_TEST_MSSQL_DRIVER',
-                            'ODBC Driver 17 for SQL Server')
+                            'ODBC Driver 18 for SQL Server')
     return driver.replace(' ', '+')
 
 
 @pytest.fixture
 def mssql_dsn(mssql_db_user, mssql_db_password, mssql_db_driver, db_name):
-    return 'mssql+pyodbc://{}:{}@localhost/{}?driver={}'\
+    return 'mssql+pyodbc://{}:{}@localhost/{}?driver={}&TrustServerCertificate=yes'\
         .format(mssql_db_user, mssql_db_password, db_name, mssql_db_driver)
 
 

--- a/sqlalchemy_utils/functions/database.py
+++ b/sqlalchemy_utils/functions/database.py
@@ -655,6 +655,18 @@ def drop_database(url):
             # Drop the database.
             text = f'DROP DATABASE {quote(conn, database)}'
             conn.execute(sa.text(text))
+    elif dialect_name == 'mssql':
+        with engine.begin() as conn:
+            # Set the database to single user mode to disconnect all users
+            text = f'''
+            ALTER DATABASE {quote(conn, database)}
+            SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+            '''
+            conn.execute(sa.text(text))
+
+            # Drop the database
+            text = f'DROP DATABASE {quote(conn, database)}'
+            conn.execute(sa.text(text))
     else:
         with engine.begin() as conn:
             text = f'DROP DATABASE {quote(conn, database)}'

--- a/sqlalchemy_utils/functions/database.py
+++ b/sqlalchemy_utils/functions/database.py
@@ -648,3 +648,5 @@ def drop_database(url):
         with engine.begin() as conn:
             text = f'DROP DATABASE {quote(conn, database)}'
             conn.execute(sa.text(text))
+
+    engine.dispose()


### PR DESCRIPTION
# Upgrade MSSQL driver from ODBC 17 to ODBC 18 with connection handling improvements

This PR upgrades the Microsoft SQL Server driver from ODBC Driver 17 to ODBC Driver 18, making several necessary adjustments to ensure proper functionality:

## Changes
- Updated the installation script to use `msodbcsql18` instead of `msodbcsql17`
- Changed the default MSSQL driver in the test configuration to "ODBC Driver 18 for SQL Server"
- Added `TrustServerCertificate=yes` parameter to the connection string to address SSL certificate validation issues with the newer driver
- Streamlined database operations by using `isolation_level='AUTOCOMMIT'` consistently
- Simplified the database cleanup code in MSSQL by removing redundant logic while maintaining proper connection handling
- Removing piece of code that was cleaning running transactions because AUTOCOMMIT was not set to True in `database_exists`

## Additional Updates
- Removed Ubuntu 20.04 test configuration for Python 3.9, as GitHub is retiring Ubuntu 20.04 runners on April 15, 2025 (see https://github.com/actions/runner-images/issues/11101)
- Added specific handling for MSSQL in the `database_exists` function, improving reliability

These changes ensure compatibility with current Microsoft SQL Server drivers while maintaining support across all tested Python versions and SQLAlchemy versions.