### PR TITLE
Add python_type property to TSVectorType for better type handling

### DIFF
--- a/sqlalchemy_utils/types/ts_vector.py
+++ b/sqlalchemy_utils/types/ts_vector.py
@@ -84,6 +84,10 @@ class TSVectorType(sa.types.TypeDecorator):
     impl = TSVECTOR
     cache_ok = True
 
+    @property
+    def python_type(self) -> type[str]:
+        return str
+    
     class comparator_factory(TSVECTOR.Comparator):
         def match(self, other, **kwargs):
             if 'postgresql_regconfig' not in kwargs:


### PR DESCRIPTION
adds a python_type property to TSVectorType for compatibility with SQLAlchemy v2 "native" column types, which are expected to implement this attribute. Previously, TSVectorType was missing this property, which could cause issues with type introspection and ORM features that rely on python_type.
Link issue https://github.com/benavlabs/crudadmin/issues/21