### PR TITLE
Migrate off a legacy ruff pre-commit hook name

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,6 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.12.2
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix]
       - id: ruff-format

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ skip_install = True
 recreate = False
 deps = pre-commit
 commands =
-    pre-commit run --all ruff
+    pre-commit run --all ruff-check
     pre-commit run --all ruff-format
 
 [testenv:docs]


### PR DESCRIPTION
When running pre-commit, the following was displayed:

```
ruff (legacy alias).................................Passed
```

Investigation found that the hook name is now `ruff-check`, which displays the following when running pre-commit:

```
ruff check..........................................Passed
```