### PR TITLE
Remove references to, and compatibility code for, EOL Pythons

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,10 +13,6 @@ jobs:
           - '3.12'
           - '3.13'
         tox_env: ['sqlalchemy14', 'sqlalchemy2']
-        #include:
-        #  - os: 'ubuntu-20.04'
-        #    python-version: '3.6'
-        #    tox_env: 'sqlalchemy14'
     runs-on: ${{ matrix.os }}
     services:
       postgres:

--- a/sqlalchemy_utils/types/choice.py
+++ b/sqlalchemy_utils/types/choice.py
@@ -192,10 +192,6 @@ class EnumTypeImpl:
     """The implementation for the ``Enum`` usage."""
 
     def __init__(self, enum_class):
-        if Enum is None:
-            raise ImproperlyConfigured(
-                "'enum34' package is required to use 'EnumType' in Python < 3.4"
-            )
         if not issubclass(enum_class, Enum):
             raise ImproperlyConfigured('EnumType needs a class of enum defined.')
 

--- a/sqlalchemy_utils/types/timezone.py
+++ b/sqlalchemy_utils/types/timezone.py
@@ -21,10 +21,9 @@ class TimezoneType(ScalarCoercible, types.TypeDecorator):
             # 'dateutil' (default), and 'zoneinfo'.
             timezone = sa.Column(TimezoneType(backend='pytz'))
 
-    :param backend: Whether to use 'dateutil', 'pytz' or 'zoneinfo' for
-        timezones. 'zoneinfo' uses the standard library module in Python 3.9+,
-        but requires the external 'backports.zoneinfo' package for older
-        Python versions.
+    :param backend:
+        Whether to use 'dateutil', 'pytz' or 'zoneinfo' for timezones.
+        'zoneinfo' uses the standard library module.
 
     """
 
@@ -64,17 +63,7 @@ class TimezoneType(ScalarCoercible, types.TypeDecorator):
                 )
 
         elif backend == 'zoneinfo':
-            try:
-                import zoneinfo
-            except ImportError:
-                try:
-                    from backports import zoneinfo
-                except ImportError:
-                    raise ImproperlyConfigured(
-                        "'backports.zoneinfo' is required to use "
-                        "the 'zoneinfo' backend for 'TimezoneType'"
-                        'on Python version < 3.9'
-                    )
+            import zoneinfo
 
             self.python_type = zoneinfo.ZoneInfo
             self._to = zoneinfo.ZoneInfo

--- a/tests/types/test_timezone.py
+++ b/tests/types/test_timezone.py
@@ -3,10 +3,7 @@ import pytz
 import sqlalchemy as sa
 from dateutil.zoneinfo import get_zonefile_instance, tzfile
 
-try:
-    import zoneinfo
-except ImportError:
-    from backports import zoneinfo
+import zoneinfo
 
 from sqlalchemy_utils.types import timezone, TimezoneType
 


### PR DESCRIPTION
This changes removes references to, and compatibility code for, EOL Python versions.