### PR TITLE
Use pyupgrade

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,3 +14,10 @@ repos:
       - id: ruff-check
         args: [--fix]
       - id: ruff-format
+
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.20.0
+    hooks:
+      - id: pyupgrade
+        name: "Enforce Python 3.9+ idioms"
+        args: ["--py39-plus"]

--- a/sqlalchemy_utils/expressions.py
+++ b/sqlalchemy_utils/expressions.py
@@ -21,7 +21,7 @@ def compile_array_get(element, compiler, **kw):
 
     if not hasattr(args[1], 'value') or not isinstance(args[1].value, int):
         raise Exception('Second argument should be an integer.')
-    return '({})[{}]'.format(compiler.process(args[0]), sa.text(str(args[1].value + 1)))
+    return f'({compiler.process(args[0])})[{sa.text(str(args[1].value + 1))}]'
 
 
 class row_to_json(GenericFunction):

--- a/sqlalchemy_utils/functions/orm.py
+++ b/sqlalchemy_utils/functions/orm.py
@@ -230,7 +230,7 @@ def get_column_key(model, column):
             if c.name == column.name and c.table is column.table:
                 return key
     raise sa.orm.exc.UnmappedColumnError(
-        'No column %s is configured on mapper %s...' % (column, mapper)
+        f'No column {column} is configured on mapper {mapper}...'
     )
 
 

--- a/sqlalchemy_utils/primitives/ltree.py
+++ b/sqlalchemy_utils/primitives/ltree.py
@@ -148,9 +148,7 @@ class Ltree:
             return Ltree(self.path.split('.')[key])
         elif isinstance(key, slice):
             return Ltree('.'.join(self.path.split('.')[key]))
-        raise TypeError(
-            'Ltree indices must be integers, not {}'.format(key.__class__.__name__)
-        )
+        raise TypeError(f'Ltree indices must be integers, not {key.__class__.__name__}')
 
     def lca(self, *others):
         """

--- a/sqlalchemy_utils/primitives/weekdays.py
+++ b/sqlalchemy_utils/primitives/weekdays.py
@@ -40,7 +40,7 @@ class WeekDays:
         return value in self._days
 
     def __repr__(self):
-        return '{}({!r})'.format(self.__class__.__name__, self.as_bit_string())
+        return f'{self.__class__.__name__}({self.as_bit_string()!r})'
 
     def __unicode__(self):
         return ', '.join(str(day) for day in self)

--- a/sqlalchemy_utils/types/pg_composite.py
+++ b/sqlalchemy_utils/types/pg_composite.py
@@ -173,9 +173,7 @@ class CompositeType(UserDefinedType, SchemaType):
             try:
                 type_ = self.type.typemap[key]
             except KeyError:
-                raise KeyError(
-                    "Type '{}' doesn't have an attribute: '{}'".format(self.name, key)
-                )
+                raise KeyError(f"Type '{self.name}' doesn't have an attribute: '{key}'")
 
             return CompositeElement(self.expr, key, type_)
 


### PR DESCRIPTION
This PR introduces pyupgrade as a pre-commit hook to enforce Python 3.9+ syntax idioms.

After introducing the pre-commit hook, `pre-commit run -a` was run.