### PR TITLE
Fix AttributeError with Sequence defaults in instant_defaults_listener

### DIFF
--- a/sqlalchemy_utils/listeners.py
+++ b/sqlalchemy_utils/listeners.py
@@ -24,7 +24,9 @@ def instant_defaults_listener(target, args, kwargs):
 
     for key, column in sa.inspect(target.__class__).columns.items():
         if hasattr(column, 'default') and column.default is not None:
-            if callable(column.default.arg):
+            if not hasattr(column.default, 'arg'):
+                continue
+            elif callable(column.default.arg):
                 kwargs[key] = column.default.arg(target)
             else:
                 kwargs[key] = column.default.arg

--- a/tests/test_instant_defaults_listener.py
+++ b/tests/test_instant_defaults_listener.py
@@ -28,6 +28,20 @@ def Article(Base):
     return Article
 
 
+@pytest.fixture
+def Document(Base):
+    class Document(Base):
+        __tablename__ = 'document'
+        id = sa.Column(
+            sa.Integer,
+            sa.Sequence('document_id_seq'),
+            primary_key=True
+        )
+        title = sa.Column(sa.Unicode(255), default='Untitled')
+
+    return Document
+
+
 class TestInstantDefaultListener:
     def test_assigns_defaults_on_object_construction(self, Article):
         article = Article()
@@ -40,3 +54,8 @@ class TestInstantDefaultListener:
     def test_override_default_with_setter_function(self, Article):
         article = Article(byline='provided byline')
         assert article.byline == 'provided byline'
+
+    def test_handles_sequence_defaults(self, Document):
+        document = Document()
+        assert document.title == 'Untitled'
+        assert document.id is None


### PR DESCRIPTION
The instant_defaults_listener was raising AttributeError when encountering columns with Sequence defaults, as it attempted to access the 'arg' attribute which doesn't exist on Sequence objects (only on ColumnDefault objects).

This occurred when using force_instant_defaults() with models that have database sequences for primary keys or other columns, causing failures in scenarios like Celery task result storage.

Resolution:
- Add hasattr check for 'arg' attribute before accessing it
- This generic approach handles Sequence and any other default types that don't have an 'arg' attribute
- Add test case covering Sequence defaults to prevent regression