### PR TITLE
Fix PasswordType dropping updates when column was previously NULL (#777)

### DIFF
--- a/sqlalchemy_utils/types/password.py
+++ b/sqlalchemy_utils/types/password.py
@@ -42,6 +42,12 @@ class Password(Mutable):
 
     def __eq__(self, value):
         if self.hash is None or value is None:
+            if self.secret is not None and value is None:
+                # A pending secret (set but not yet hashed) is a real value
+                # and must not compare equal to None, otherwise SQLAlchemy's
+                # change detection sees no change and skips the UPDATE.
+                return False
+
             # Ensure that we don't continue comparison if one of us is None.
             return self.hash is value
 

--- a/sqlalchemy_utils/types/password.py
+++ b/sqlalchemy_utils/types/password.py
@@ -42,14 +42,10 @@ class Password(Mutable):
 
     def __eq__(self, value):
         if self.hash is None or value is None:
-            if self.secret is not None and value is None:
-                # A pending secret (set but not yet hashed) is a real value
-                # and must not compare equal to None, otherwise SQLAlchemy's
-                # change detection sees no change and skips the UPDATE.
-                return False
-
-            # Ensure that we don't continue comparison if one of us is None.
-            return self.hash is value
+            # If either the hash or the value is None,
+            # equivalence depends on *all* values being None,
+            # including the secret.
+            return self.hash is None and self.secret is None and value is None
 
         if isinstance(value, Password):
             # Comparing 2 hashes isn't very useful; but this equality

--- a/tests/types/test_password.py
+++ b/tests/types/test_password.py
@@ -164,7 +164,7 @@ class TestPasswordType:
     def test_update_none(self, session, User):
         """
         Should be able to change a password from ``None`` to a valid
-        password.
+        password, and the change must be persisted to the database.
         """
 
         obj = User()
@@ -177,6 +177,15 @@ class TestPasswordType:
         obj.password = 'b'
 
         session.commit()
+
+        # Re-read from the database to confirm the None -> 'b' update was
+        # actually persisted and not dropped by change detection.
+        session.expire_all()
+        obj = session.get(User, obj.id)
+
+        assert obj.password is not None
+        assert obj.password == b'b'
+        assert obj.password != 'a'
 
     def test_pending_password_not_equal_to_none(self):
         """

--- a/tests/types/test_password.py
+++ b/tests/types/test_password.py
@@ -178,6 +178,27 @@ class TestPasswordType:
 
         session.commit()
 
+    def test_pending_password_not_equal_to_none(self):
+        """
+        A pending (coerced but not-yet-hashed) password holds a real secret
+        and must not compare equal to ``None``.
+
+        If it did, SQLAlchemy's scalar change detection would treat setting a
+        value on a previously-``NULL`` column as "unchanged" and skip the
+        ``UPDATE``, silently dropping the new password.
+        """
+
+        pending = Password('b', secret=True)
+
+        assert pending.hash is None
+        assert pending.secret == 'b'
+        assert not (pending == None)  # noqa: E711
+        assert pending != None  # noqa: E711
+
+        # A genuinely empty password still equals ``None``.
+        empty = Password(None)
+        assert empty == None  # noqa: E711
+
     def test_compare_none(self, User):
         """
         Should be able to compare a password of ``None``.


### PR DESCRIPTION
## Summary

Fixes #777.

A `PasswordType` column that was persisted as `NULL` silently drops a subsequently-assigned password: the row stays `NULL` in the database even though the ORM object appears to hold the new value.

```python
class User(Base):
    __tablename__ = "user"
    id: Mapped[int] = mapped_column(primary_key=True)
    password = mapped_column(PasswordType(schemes=["pbkdf2_sha512"]), nullable=True)

# insert a row whose password is NULL
u = User(password=None); session.add(u); session.commit()

# later, in a fresh session, load it and set a real password
u = session.get(User, u.id)   # u.password is None
u.password = "swordfish"
session.commit()              # <-- no UPDATE is emitted; column stays NULL
```

## Root cause

The defect is in `Password.__eq__`.

Assigning a plain string to the column (the default configuration, i.e. without `force_auto_coercion()`) produces a **pending** `Password` object that keeps the plaintext in `.secret` with `.hash` still `None` — it is not hashed until `process_bind_param` runs at flush time.

SQLAlchemy's scalar change detection compares the new attribute value against the committed value with `__eq__`. For a row whose committed value was `None`, this evaluates `Password(secret=...) == None`. The method only looked at `.hash`:

```python
def __eq__(self, value):
    if self.hash is None or value is None:
        return self.hash is value   # None is None -> True
```

so it reported the pending password as **equal to `None`**. SQLAlchemy therefore concluded "no change", placed the value in `history.unchanged`, and emitted no `UPDATE`. The password was lost.

This only manifests in the default configuration: with `force_auto_coercion()` / the coercion listener active, assignment hashes immediately (`.hash` becomes bytes), which is why the existing `test_update_none` — which never asserted persistence — did not catch it.

## Fix

Treat a pending secret as a real value: a `Password` whose `.secret` is set is never equal to `None`. A genuinely empty `Password` (`hash is None and secret is None`) still compares equal to `None`, so `test_compare_none` / `test_set_none` behaviour is preserved.

```diff
 def __eq__(self, value):
     if self.hash is None or value is None:
+        if self.secret is not None and value is None:
+            # A pending secret (set but not yet hashed) is a real value
+            # and must not compare equal to None, otherwise SQLAlchemy's
+            # change detection sees no change and skips the UPDATE.
+            return False
+
         # Ensure that we don't continue comparison if one of us is None.
         return self.hash is value
```

## Before / after

| `Password` state | `== None` before | `== None` after |
| --- | --- | --- |
| `hash=<bytes>, secret=None` (hashed) | `False` | `False` |
| `hash=None, secret='b'` (pending) | **`True` (bug)** | **`False` (fixed)** |
| `hash=None, secret=None` (empty) | `True` | `True` (preserved) |

## Tests

Adds `test_pending_password_not_equal_to_none`, a deterministic unit test on `Password.__eq__` (independent of the coercion configuration, so it exercises the root cause directly).

Proof it guards the bug:

```
# without the fix
$ pytest tests/types/test_password.py::TestPasswordType::test_pending_password_not_equal_to_none -q
>       assert not (pending == None)  # noqa: E711
E       assert not <...Password object...> == None
1 failed

# with the fix
$ pytest tests/types/test_password.py -q
....................                                                     [100%]
20 passed
```

`ruff check` passes on both changed files; the pre-existing `ruff format` diff in `test_password.py` is confined to unrelated fixtures and is untouched by this change.
