### PR TITLE
Fix ChoiceType returning raw scalar for falsy codes (0, empty string)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,11 @@ Changelog
 
 Here you can see the full list of changes between each SQLAlchemy-Utils release.
 
+Unreleased
+^^^^^^^^^^
+
+- Fix ``ChoiceType`` returning the raw scalar instead of a ``Choice`` for falsy codes such as ``0`` or the empty string (#813)
+
 0.42.1 (2025-12-12)
 ^^^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,9 @@ Here you can see the full list of changes between each SQLAlchemy-Utils release.
 Unreleased
 ^^^^^^^^^^
 
-- Fix ``ChoiceType`` returning the raw scalar instead of a ``Choice`` for falsy codes such as ``0`` or the empty string (#813)
+- Fix ``ChoiceType`` returning the raw scalar instead of a ``Choice`` for falsy codes such as ``0`` or the empty string. (#813)
+
+  NULL values continue to return ``None``.
 
 0.42.1 (2025-12-12)
 ^^^^^^^^^^^^^^^^^^^

--- a/sqlalchemy_utils/types/choice.py
+++ b/sqlalchemy_utils/types/choice.py
@@ -183,9 +183,9 @@ class ChoiceTypeImpl:
         return value
 
     def process_result_value(self, value, dialect):
-        if value is not None:
-            return Choice(value, self.choices_dict[value])
-        return value
+        if value is None:
+            return None
+        return Choice(value, self.choices_dict[value])
 
 
 class EnumTypeImpl:

--- a/sqlalchemy_utils/types/choice.py
+++ b/sqlalchemy_utils/types/choice.py
@@ -183,7 +183,7 @@ class ChoiceTypeImpl:
         return value
 
     def process_result_value(self, value, dialect):
-        if value:
+        if value is not None:
             return Choice(value, self.choices_dict[value])
         return value
 

--- a/tests/types/test_choice.py
+++ b/tests/types/test_choice.py
@@ -209,3 +209,71 @@ class TestEnumType:
         session.commit()
 
         assert order_nullable.status is None
+
+
+class TestChoiceTypeFalsyCode:
+    """A list-of-tuples ``ChoiceType`` must coerce *every* non-NULL stored
+    code back into a :class:`Choice`, exactly like the ``Enum`` variant does.
+
+    A falsy-but-valid code (integer ``0`` or the empty string) used to be
+    returned verbatim from the database because ``process_result_value``
+    tested ``if value:`` instead of ``if value is not None:``. The ``Enum``
+    sibling already guards with ``is None`` (see
+    ``TestEnumType.test_setting_value_that_resolves_to_none``), so the two
+    implementations disagreed on the shared contract.
+    """
+
+    @pytest.fixture
+    def Item(self, Base):
+        class Item(Base):
+            STATUSES = [(0, 'inactive'), (1, 'active')]
+
+            __tablename__ = 'item'
+            id = sa.Column(sa.Integer, primary_key=True)
+            status = sa.Column(ChoiceType(STATUSES, impl=sa.Integer()))
+
+        return Item
+
+    @pytest.fixture
+    def init_models(self, Item):
+        pass
+
+    def test_result_value_wraps_falsy_int_code(self):
+        type_ = ChoiceType([(0, 'inactive'), (1, 'active')], impl=sa.Integer())
+        result = type_.process_result_value(0, None)
+        assert isinstance(result, Choice)
+        assert result.code == 0
+        assert result.value == 'inactive'
+
+    def test_result_value_wraps_empty_string_code(self):
+        type_ = ChoiceType([('', 'blank'), ('a', 'Letter A')])
+        result = type_.process_result_value('', None)
+        assert isinstance(result, Choice)
+        assert result.code == ''
+        assert result.value == 'blank'
+
+    def test_matches_enum_sibling_for_falsy_code(self):
+        class Status(Enum):
+            inactive = 0
+            active = 1
+
+        tuple_type = ChoiceType([(0, 'inactive'), (1, 'active')], impl=sa.Integer())
+        enum_type = ChoiceType(Status, impl=sa.Integer())
+
+        # Both siblings must wrap the falsy code, not leak the raw scalar.
+        assert type(tuple_type.process_result_value(0, None)) is Choice
+        assert enum_type.process_result_value(0, None) is Status.inactive
+        assert tuple_type.process_result_value(0, None) is not None
+
+    def test_falsy_code_roundtrips_through_database(self, session, Item):
+        item = Item()
+        item.status = 0
+
+        session.add(item)
+        session.commit()
+
+        item = session.query(Item).first()
+        assert isinstance(item.status, Choice)
+        assert item.status.code == 0
+        assert item.status.value == 'inactive'
+        assert item.status == 0

--- a/tests/types/test_choice.py
+++ b/tests/types/test_choice.py
@@ -212,15 +212,9 @@ class TestEnumType:
 
 
 class TestChoiceTypeFalsyCode:
-    """A list-of-tuples ``ChoiceType`` must coerce *every* non-NULL stored
-    code back into a :class:`Choice`, exactly like the ``Enum`` variant does.
-
-    A falsy-but-valid code (integer ``0`` or the empty string) used to be
-    returned verbatim from the database because ``process_result_value``
-    tested ``if value:`` instead of ``if value is not None:``. The ``Enum``
-    sibling already guards with ``is None`` (see
-    ``TestEnumType.test_setting_value_that_resolves_to_none``), so the two
-    implementations disagreed on the shared contract.
+    """A list-of-tuples ``ChoiceType`` must coerce *every* non-NULL value
+    back into a :class:`Choice`, including false-y values like ``0``
+    or the empty string.
     """
 
     @pytest.fixture
@@ -274,6 +268,7 @@ class TestChoiceTypeFalsyCode:
 
         item = session.query(Item).first()
         assert isinstance(item.status, Choice)
+        assert type(item.status.code) is int  # must be an int, not a bool
         assert item.status.code == 0
         assert item.status.value == 'inactive'
         assert item.status == 0


### PR DESCRIPTION
The list-of-tuples `ChoiceType` fails to coerce a valid but *falsy* stored code back into a `Choice`, while the `Enum` variant handles it correctly — the two sibling implementations disagree on their shared contract.

```python
import sqlalchemy as sa
from sqlalchemy_utils.types.choice import ChoiceType

t = ChoiceType([(0, "inactive"), (1, "active")], impl=sa.Integer())
t.process_result_value(0, None)   # -> 0        (raw int, WRONG)
t.process_result_value(1, None)   # -> <Choice code=1 ...>   (correct)
```

So reading a row whose stored code is `0` (a very common pattern for integer choice lists) or `""` (empty-string code) yields the raw scalar instead of a `Choice`, e.g. `item.status` comes back as `0` rather than `Choice(0, "inactive")`.

**Cause.** `ChoiceTypeImpl.process_result_value` tests `if value:` (truthiness), which is false for `0`/`""`. The `Enum` sibling `EnumTypeImpl.process_result_value` guards with `is None` (via `_coerce`), and `_coerce` itself uses `is None` — only this implementation used truthiness.

**Fix.** Guard with `is None`, matching the sibling and `_coerce`. `process_bind_param` needs no change (a `Choice` is truthy and raw codes pass through unchanged).

**Tests** (`tests/types/test_choice.py`, `TestChoiceTypeFalsyCode`): the falsy int code `0` and empty-string code now wrap into a `Choice`; an explicit parity assertion that the tuple-list and `Enum` variants agree on code `0`; and a full SQLite round-trip asserting `item.status` reads back as `Choice(0, "inactive")`. `tests/types/test_choice.py`: 21 passed.