### PR TITLE
Remove badges from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,6 @@
 SQLAlchemy-Utils
 ================
 
-|Build| |Version Status| |Downloads|
-
 Various utility functions, new data types and helpers for SQLAlchemy.
 
 
@@ -12,11 +10,3 @@ Resources
 - `Documentation <https://sqlalchemy-utils.readthedocs.io/>`_
 - `Issue Tracker <https://github.com/kvesteri/sqlalchemy-utils/issues>`_
 - `Code <https://github.com/kvesteri/sqlalchemy-utils/>`_
-
-.. |Build| image:: https://github.com/kvesteri/sqlalchemy-utils/actions/workflows/test.yaml/badge.svg?branch=master
-   :target: https://github.com/kvesteri/sqlalchemy-utils/actions/workflows/test.yaml
-   :alt: Tests
-.. |Version Status| image:: https://img.shields.io/pypi/v/SQLAlchemy-Utils.svg
-   :target: https://pypi.python.org/pypi/SQLAlchemy-Utils/
-.. |Downloads| image:: https://img.shields.io/pypi/dm/SQLAlchemy-Utils.svg
-   :target: https://pypi.python.org/pypi/SQLAlchemy-Utils/


### PR DESCRIPTION
Badges embedded in the README are frozen in time on PyPI and can age poorly. At the time of this commit, for example, one of the badges says "rate limited by upstream service".

Removing the badges is an easy way to help ensure
longevity for frozen versions of the README.