### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,22 +1,22 @@
-# Run `pre-commit autoupdate` to update the hook versions.
+# Run `tox -e update-pre-commit` to update the hook versions.
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.14
+    rev: 3b3f7c3f57fe9925356faf5fe6230835138be230  # frozen: v0.15.17
     hooks:
       - id: ruff-check
         args: [--fix]
       - id: ruff-format
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.21.2
+    rev: 75992aaa40730136014f34227e0135f63fc951b4  # frozen: v3.21.2
     hooks:
       - id: pyupgrade
         name: "Enforce Python 3.9+ idioms"

--- a/tox.ini
+++ b/tox.ini
@@ -68,14 +68,14 @@ skip_install = true
 deps =
     requirements: poetry
     requirements: poetry-plugin-export
-    pre-commit: pre-commit
+    pre-commit: prek
 commands =
     # Update requirements files
     requirements: poetry update --directory="requirements/docs" --lock
     requirements: poetry export --directory="requirements/docs" --output="requirements.txt" --without-hashes
 
     # Update pre-commit hook versions
-    pre-commit: pre-commit autoupdate
+    pre-commit: prek autoupdate --freeze --cooldown-days 20
 
     # Run pre-commit immediately, but ignore its exit code
-    pre-commit: - pre-commit run -a
+    pre-commit: - prek run -a


### PR DESCRIPTION
In addition, configure the tox `update-pre-commit` environment to freeze the hook versions, with a 20-day cooldown period.